### PR TITLE
added: consider .C files as C++

### DIFF
--- a/src/SeerEditorWidgetSourceArea.cpp
+++ b/src/SeerEditorWidgetSourceArea.cpp
@@ -620,7 +620,7 @@ void SeerEditorWidgetSourceArea::openText (const QString& text, const QString& f
         delete _sourceHighlighter; _sourceHighlighter = 0;
     }
 
-    QRegExp cpp_re("(?:.c|.cpp|.CPP|.cxx|.CXX|.h|.H|.hpp|.hxx|.Hxx|.HXX)$");
+    QRegExp cpp_re("(?:.c|.C|.cpp|.CPP|.cxx|.CXX|.h|.H|.hpp|.hxx|.Hxx|.HXX)$");
     if (file.contains(cpp_re)) {
         _sourceHighlighter = new SeerCppSourceHighlighter(0);
 

--- a/src/SeerSourceBrowserWidget.cpp
+++ b/src/SeerSourceBrowserWidget.cpp
@@ -100,7 +100,7 @@ void SeerSourceBrowserWidget::handleText (const QString& text) {
             */
 
             // Look at the filename suffix.
-            if (fileInfo.suffix() == "cpp" || fileInfo.suffix() == "c") { // C/C++
+            if (fileInfo.suffix() == "cpp" || fileInfo.suffix() == "c" || fileInfo.suffix() == "C") { // C/C++
                 _sourceFilesItems->addChild(item);
 
             }else if (fileInfo.suffix() == "f" || fileInfo.suffix() == "f90" || fileInfo.suffix() == "F90") { // Fortran


### PR DESCRIPTION
Not that common, but it is used in some projects. This enables syntax highlighting and 'source' grouping for .C files.