### PR TITLE
Small correction to build instructions

### DIFF
--- a/src/build/README.cmake
+++ b/src/build/README.cmake
@@ -7,7 +7,7 @@ Notes for building Seer with cmake.
 
 
 % make clean                            # Clean files.
-% make seer                             # Build Seer.
+% make seergdb                          # Build Seer.
 % sudo make install                     # Install it.
 
 % cmake --build . --config Release


### PR DESCRIPTION
In the src/build dir the instructions say `make seer`, probably left over from the time the executable was called that.