### PR TITLE
Updates to build on Ubuntu 18.04 LTS (…)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@ Seer - a gui frontend to gdb for Linux.   (Ernie Pasveer  epasveer@att.net)
 This project is actively worked on. The aim is a simple, yet pleasing gui to gdb.
 
 Please report any bugs or desired features to my email or create a task in my
-github project page.
+GitHub project page.
 
 
 Requirements
 ============
 
-    * Linux
-    * C++17
-    * gdb with "mi" interpreter
-    * QT5 (5.15.2 or newer)
-    * QT5 QtCharts (5.15.2 or newer)
-    * QT5.12 is supported but has certain limitations.
-    * When building Seer from source, you will need the QT5 "devel" packages
-      installed on your system for your distribution.
+* Linux
+* C++17
+* gdb with "mi" interpreter
+* CMake (3.10 or newer)
+* QT5 (5.15.2 or newer)
+* QT5 QtCharts (5.15.2 or newer)
+* QT as old as 5.9.5 (e.g., Ubuntu 18.04 LTS) is supported but has certain limitations.
+* When building Seer from source, you will need the QT5 "devel" packages
+  installed on your system for your distribution.
 
 NOTE
 ====
@@ -39,63 +40,63 @@ Main View
 The main view for Seer looks like:
 ![](images/mainview.png)
 
-    * Source/Function/Types/Variables/Libraries
-        * The list of source/header files that were used in the program.
-        * Search for Functions, Types, and Static Variables.
-          Dobule clicking will open the source file.
-        * The list of shared libraries referenced by the program.
-        * The list of source/header files can be searched in. This will "shrink" the list of files shown.
-        * Double clicking on a file will open it in the Code Manager.
+* Source/Function/Types/Variables/Libraries
+    * The list of source/header files that were used in the program.
+    * Search for Functions, Types, and Static Variables.
+      Dobule clicking will open the source file.
+    * The list of shared libraries referenced by the program.
+    * The list of source/header files can be searched in. This will "shrink" the list of files shown.
+    * Double clicking on a file will open it in the Code Manager.
 
-    * Variable/Register Info
-        * Show variable and register values.
-        * "Logger" - log the value of a variable. Manually enter it or double click on the variable in the file
-          that is opened in the code manager.
-        * "Tracker" - create a list of variables to show the value for whenever gdb reaches a stopping point.
-          (step, next, finish, etc.) When the stopping point is reached, all variables in the list will show
-          their potentially new value.
-        * "Registers" - show the values of all cpu registgers.
+* Variable/Register Info
+    * Show variable and register values.
+    * "Logger" - log the value of a variable. Manually enter it or double click on the variable in the file
+      that is opened in the code manager.
+    * "Tracker" - create a list of variables to show the value for whenever gdb reaches a stopping point.
+      (step, next, finish, etc.) When the stopping point is reached, all variables in the list will show
+      their potentially new value.
+    * "Registers" - show the values of all cpu registgers.
 
-    * Code Manager.
-        * The large area of the middle part of the Seer gui.
-        * Source files are opened in this view.
-        * Text in a file can be seached for with ^F.
-        * Variables can be added to the "Logger" by double clicking the variable name.
-          Double click with CTLR key pressed will prepend variable with "*".
-          Double click with SHIFT key pressed will prepend variable with "&".
-          Double click with CTRL+SHIFT key pressed will prepend variable with "*&".
-        * Variables can be added to the "Tracker" by selecting the varible name and RMB and select
-          "Add variable to Tracker".
-        * Variables can be added to the "Memory Visualizer" by selecting the varible name and RMB and select
-          "Add variable to Memory Visualizer".
-        * A breakpoint/printpoint can be created by RMB on a specific line.
-        * Can execute to a specific line by RMB on a specific line.
-        * Tabs in this view can be detached by double-clicking a tab.
+* Code Manager.
+    * The large area of the middle part of the Seer gui.
+    * Source files are opened in this view.
+    * Text in a file can be seached for with ^F.
+    * Variables can be added to the "Logger" by double clicking the variable name.
+      Double click with CTLR key pressed will prepend variable with "*".
+      Double click with SHIFT key pressed will prepend variable with "&".
+      Double click with CTRL+SHIFT key pressed will prepend variable with "*&".
+    * Variables can be added to the "Tracker" by selecting the varible name and RMB and select
+      "Add variable to Tracker".
+    * Variables can be added to the "Memory Visualizer" by selecting the varible name and RMB and select
+      "Add variable to Memory Visualizer".
+    * A breakpoint/printpoint can be created by RMB on a specific line.
+    * Can execute to a specific line by RMB on a specific line.
+    * Tabs in this view can be detached by double-clicking a tab.
 
-    * Breakpoints, Watchpoints, Catchpoints, Printpoints, manual gdb commands, and logs.
-        * The area below the Code Manager.
-        * Manual commands.  Manually enter a gdb or gdbmi command.
-          The commands are remembered for the next Seer use.
-        * Breakpoint manager. Create and manage breakpoints.
-        * Watchpoint manager. Create and manage watchpoints.
-          A watchpoint monitors when a variable is accessed (read, write, read/write).
-        * Catchpoint manager. Create and manage catchpoints.
-          A catchpoint stops execution on a C++ throw/rethrow/catch call.
-        * Printpoint manager. Create and manage printpoints.
-          A printpoint is like a breakpoint but it allows you to print variables at
-          that printpoint. See gdb's 'dprintf' call.
-        * GDB output. A log of any output from the gdb program itself.
-        * Seer output. A log of any output from the Seer program itself. As diagnostics.
-        * Tabs in this view can be detached by double-clicking a tab.
+* Breakpoints, Watchpoints, Catchpoints, Printpoints, manual gdb commands, and logs.
+    * The area below the Code Manager.
+    * Manual commands.  Manually enter a gdb or gdbmi command.
+      The commands are remembered for the next Seer use.
+    * Breakpoint manager. Create and manage breakpoints.
+    * Watchpoint manager. Create and manage watchpoints.
+      A watchpoint monitors when a variable is accessed (read, write, read/write).
+    * Catchpoint manager. Create and manage catchpoints.
+      A catchpoint stops execution on a C++ throw/rethrow/catch call.
+    * Printpoint manager. Create and manage printpoints.
+      A printpoint is like a breakpoint but it allows you to print variables at
+      that printpoint. See gdb's 'dprintf' call.
+    * GDB output. A log of any output from the gdb program itself.
+    * Seer output. A log of any output from the Seer program itself. As diagnostics.
+    * Tabs in this view can be detached by double-clicking a tab.
 
-    * Stack frame information.
-        * Stack frame list. A frame can be double clicked to change the scope (the current function).
-        * Stack frame arguments. For each frame, print the arguments passed to each function.
-        * Stack locals. For the current function, print the values of the local variables.
+* Stack frame information.
+    * Stack frame list. A frame can be double clicked to change the scope (the current function).
+    * Stack frame arguments. For each frame, print the arguments passed to each function.
+    * Stack locals. For the current function, print the values of the local variables.
 
-    * Thread information.
-        * Thread ids. A list of all threads. Double click on a thread id to change the scope (the current thread).
-        * Thread frames. For each thread, list its stack frames.
+* Thread information.
+    * Thread ids. A list of all threads. Double click on a thread id to change the scope (the current thread).
+    * Thread frames. For each thread, list its stack frames.
 
 Open Dialog
 -----------
@@ -259,6 +260,6 @@ package containing Seer. You need the `build-essential` package installed.
 Support/Contact
 ===============
 
-    Send an email to epasveer@att.net for any bugs or features. Or create a task
-    in my github project page.
+Send an email to epasveer@att.net for any bugs or features. Or create a task
+in my GitHub project page.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -204,7 +204,7 @@ if(UNIX AND NOT APPLE)
     add_compile_options(-Wall -Wextra -Wunused-result -pedantic)   # -Werror -Wdeprecated-copy
 endif()
 
-add_compile_definitions(QT_DEPRECATED_WARNINGS)
+add_definitions(-DQT_DEPRECATED_WARNINGS)
 
 add_executable(${PROJECT_NAME} ${SYSTEM_TYPE} ${SOURCE_FILES})
 

--- a/src/SeerEditorWidgetAssemblyAreas.cpp
+++ b/src/SeerEditorWidgetAssemblyAreas.cpp
@@ -138,7 +138,11 @@ int SeerEditorWidgetAssemblyArea::lineNumberAreaWidth () {
         b++;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     int space = 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * chars;
+#else
+    int space = 3 + fontMetrics().width(QLatin1Char('9')) * chars;
+#endif
 
     return space;
 }
@@ -356,8 +360,16 @@ void SeerEditorWidgetAssemblyArea::miniMapAreaPaintEvent (QPaintEvent* event) {
 
             while (block.isValid()) {
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
                 if (fm.horizontalAdvance(block.text()) > pixmapWidth) {
+#else
+                if (fm.width(block.text()) > pixmapWidth) {
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
                     pixmapWidth = fm.horizontalAdvance(block.text());
+#else
+                    pixmapWidth = fm.width(block.text());
+#endif
                 }
 
                 pixmapHeight += fm.height();

--- a/src/SeerEditorWidgetSourceAreas.cpp
+++ b/src/SeerEditorWidgetSourceAreas.cpp
@@ -129,7 +129,11 @@ int SeerEditorWidgetSourceArea::lineNumberAreaWidth () {
         digits++;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     int space = 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+#else
+    int space = 3 + fontMetrics().width(QLatin1Char('9')) * digits;
+#endif
 
     return space;
 }
@@ -340,8 +344,16 @@ void SeerEditorWidgetSourceArea::miniMapAreaPaintEvent (QPaintEvent* event) {
 
             while (block.isValid()) {
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
                 if (fm.horizontalAdvance(block.text()) > pixmapWidth) {
+#else
+                if (fm.width(block.text()) > pixmapWidth) {
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
                     pixmapWidth = fm.horizontalAdvance(block.text());
+#else
+                    pixmapWidth = fm.width(block.text());
+#endif
                 }
 
                 pixmapHeight += fm.height();

--- a/src/SeerGdbLogWidget.cpp
+++ b/src/SeerGdbLogWidget.cpp
@@ -17,44 +17,76 @@ void SeerGdbLogWidget::processText (const QString& text) {
     // Remove leading "~"
     // ~"For help, type "help".
     // "
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (text.front() == '~') {
-
+#else
+    if (text.at(0) == '~') {
+#endif
         str = text.mid(1);
 
         // Remove leading """
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
         if (str.front() == '"') {
+#else
+        if (str.at(0) == '"') {
+#endif
             str = str.mid(1);
         }
 
         // Remove trailing """
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
         if (str.back() == '"') {
+#else
+        if (str.at(str.size() - 1) == '"') {
+#endif
+
             str.chop(1);
         }
 
         // Remove trailing "\n"
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
         if (str.back() == '\n') {
+#else
+        if (str.at(str.size() - 1) == '\n') {
+#endif
             str.chop(1);
         }
 
     // Remove leading "&"
     // &"p name
     // "
-    }else if (text.front() == '&') {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    } else if (text.front() == '&') {
+#else
+    } else if (text.at(0) == '&') {
+#endif
 
         str = text.mid(1);
 
         // Remove leading """
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
         if (str.front() == '"') {
+#else
+        if (str.at(0) == '"') {
+#endif
             str = str.mid(1);
         }
 
         // Remove trailing """
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
         if (str.back() == '"') {
+#else
+        if (str.at(str.size() - 1) == '"') {
+#endif
             str.chop(1);
         }
 
         // Remove trailing "\n"
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
         if (str.back() == '\n') {
+#else
+        if (str.at(str.size() - 1) == '\n') {
+#endif
             str.chop(1);
         }
 
@@ -68,7 +100,11 @@ void SeerGdbLogWidget::processText (const QString& text) {
     str = Seer::filterEscapes(str);
 
     // Remove trailing "\n"
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     while (str.back() == '\n') {
+#else
+    while (str.at(str.size() - 1) == '\n') {
+#endif
         str.chop(1);
         break;
     }

--- a/src/SeerHexWidget.cpp
+++ b/src/SeerHexWidget.cpp
@@ -77,7 +77,11 @@ SeerHexWidget::SeerHexWidget(QWidget* parent) : QWidget(parent), _pdata(NULL) {
     _memoryMode    = SeerHexWidget::HexMemoryMode;
     _charMode      = SeerHexWidget::AsciiCharMode;
     _addressOffset = 0;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     _charWidth     = plainTextEdit->fontMetrics().horizontalAdvance(QLatin1Char('9'));
+#else
+    _charWidth     = plainTextEdit->fontMetrics().width(QLatin1Char('9'));
+#endif
     _charHeight    = plainTextEdit->fontMetrics().height();
     _gapAddrHex    = 10; // Gap between address and hex fields.
     _gapHexAscii   = 16; // Gap between hex and ascii fields.

--- a/src/SeerPrintpointCreateDialog.cpp
+++ b/src/SeerPrintpointCreateDialog.cpp
@@ -218,13 +218,21 @@ QString SeerPrintpointCreateDialog::printpointText () const {
     // Build the format string, ensuring a \" at the beggining and end of the string.
     printpointParameters += " ";
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (format().front() != "\"") {
+#else
+    if (format().at(0) != "\"") {
+#endif
         printpointParameters += "\"";
     }
 
     printpointParameters += format();
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (format().back() != "\"") {
+#else
+    if (format().at(format().size() - 1) != "\"") {
+#endif
         printpointParameters += "\"";
     }
 

--- a/src/SeerSeerLogWidget.cpp
+++ b/src/SeerSeerLogWidget.cpp
@@ -15,15 +15,27 @@ void SeerSeerLogWidget::processText (const QString& text) {
     // Only log '^', '*', and '=' records.
     bool selected = false;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (selected == false && text.front() == '^') {
+#else
+    if (selected == false && text.at(0) == '^') {
+#endif
         selected = true;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (selected == false && text.front() == '*') {
+#else
+    if (selected == false && text.at(0) == '*') {
+#endif
         selected = true;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (selected == false && text.front() == '=') {
+#else
+    if (selected == false && text.at(0) == '=') {
+#endif
         selected = true;
     }
 

--- a/src/SeerTildeLogWidget.cpp
+++ b/src/SeerTildeLogWidget.cpp
@@ -12,17 +12,29 @@ void SeerTildeLogWidget::processText (const QString& text) {
 
     QString str = text.mid(1); // Remove leading "~"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (str.front() == '"') { // Remove leading """
+#else
+    if (str.at(0) == '"') { // Remove leading """
+#endif
         str = str.mid(1);
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (str.back() == '"') { // Remove trailing """
+#else
+    if (str.at(str.size() - 1) == '"') { // Remove trailing """
+#endif
         str.chop(1);
     }
 
     str = Seer::filterEscapes(str);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     if (str.back() == '\n') { // Remove trailing "\n"
+#else
+    if (str.at(str.size() - 1) == '\n') { // Remove trailing "\n"
+#endif
         str.chop(1);
     }
 


### PR DESCRIPTION
- replace `add_compile_definitions` (added in CMake ≥3.12) with `add_definitions` in `CMakeLists.txt`

    * hat tip to: https://stackoverflow.com/a/61250302/785213

- add #ifdef's to support Qt 5.9.5 for Ubuntu 18.04 by replacing QString `.front()` and `.back()` methods with `.at(0)` and `.at(s.size() - 1)`

    * hat tip to: https://github.com/pawelsalawa/sqlitestudio/commit/90ca398

- add #ifdef's to replace `QFontMetrics` `.horizontalAdvance()` method with `.width()` to support Qt 5.9.5 on Ubuntu 18.04

    * hat tip to: https://github.com/Sigil-Ebook/Sigil/commit/a32f890

- closes #107