### PR TITLE
Set LANG environment variable to C before running "gdb"

### DIFF
--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -2924,6 +2924,12 @@ bool SeerGdbWidget::startGdb () {
     _gdbProcess->setProgram(command);
     _gdbProcess->setArguments(args);
 
+    // We need to set the C language, otherwise the MI interface is translated and our message
+    // filters will not work.
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert("LANG", "C");
+    _gdbProcess->setProcessEnvironment(env);
+
     // Start the gdb process.
     _gdbProcess->start();
 


### PR DESCRIPTION
Otherwise the messages returned by gdb might be translated and we would be confused by gdb output.

For example, if LANG=es_ES.UTF-8, then an error dialog wit the message
 "No hay registros" ("No registers") is continually raised.