### PR TITLE
Fixed "show variable's value" on hover.

### DIFF
--- a/src/SeerEditorWidgetSource.h
+++ b/src/SeerEditorWidgetSource.h
@@ -16,6 +16,7 @@
 #include <QtCore/QVector>
 #include <QtCore/QMap>
 #include <QtCore/QFileSystemWatcher>
+#include <QtCore/QPoint>
 
 
 class SeerEditorWidgetSourceLineNumberArea;
@@ -152,6 +153,7 @@ class SeerEditorWidgetSourceArea : public SeerPlainTextEdit {
         QList<QTextEdit::ExtraSelection>            _currentLinesExtraSelections;
 
         QTextCursor                                 _selectedExpressionCursor;
+        QPoint                                      _selectedExpressionPosition;
         int                                         _selectedExpressionId;
         QString                                     _selectedExpressionName;
         QString                                     _selectedExpressionValue;

--- a/tests/helloworld/helloworld.cpp
+++ b/tests/helloworld/helloworld.cpp
@@ -1,7 +1,13 @@
 
-
 #include <string>
 #include <iostream>
+
+// argc         == number of arguments passed to the program.
+// argv         == argument array.
+// j            == some misc integer.
+// i            == loop counter for printing arguments.
+// message      == say hi to the world.
+// function1    == a function to call to simulate work.
 
 void function1 (const std::string& message);
 


### PR DESCRIPTION
This should fix the "hover" issue.

The variable's value now shows as a tooltip.  If the text is a class/function/datatype, the tooltip will show that info.

Note, you still need to select the correct frame first.  Otherwise, you'll see a tooltip like:

```
    sometext:   "sometext" is not in context
```

Let me know if it's better.
