### PR TITLE
Re-add executable argument for 'connect' mode.

### DIFF
--- a/src/SeerDebugDialog.cpp
+++ b/src/SeerDebugDialog.cpp
@@ -811,6 +811,8 @@ void SeerDebugDialog::handleRunModeChanged (int id) {
 
     // ID == 2   CONNECT
     if (id == 2) {
+        executableNameLineEdit->setEnabled(true);
+        executableNameToolButton->setEnabled(true);
         executableSymbolNameLineEdit->setEnabled(true);
         executableSymbolNameToolButton->setEnabled(true);
         executableWorkingDirectoryLineEdit->setEnabled(true);

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -1156,15 +1156,6 @@ void SeerGdbWidget::handleGdbConnectExecutable () {
 
     while (1) {
 
-        // Has a executable name been provided?
-        if (executableName() != "") {
-
-            QMessageBox::warning(this, "Seer",
-                    QString("The executable name can't be provided for 'connect' mode."),
-                    QMessageBox::Ok);
-            break;
-        }
-
         // Delete the old gdb and console if there is a new executable
         if (newExecutableFlag() == true) {
             killGdb();
@@ -1242,7 +1233,6 @@ void SeerGdbWidget::handleGdbRRExecutable () {
 
         // Has a executable name been provided?
         if (executableName() != "") {
-
             QMessageBox::warning(this, "Seer",
                     QString("The executable name can't be provided for 'rr' mode."),
                     QMessageBox::Ok);

--- a/src/resources/help/ConnectDebugMode.md
+++ b/src/resources/help/ConnectDebugMode.md
@@ -10,6 +10,7 @@ something to connect to it. When Seer connects with it, the process is ready to 
 ### Requirements
 In this mode, Seer needs:
 
+* Optional executable file if the remote gdbserver/gdbstub hasn't loaded one
 * Optional symbol file if the executable doesn't have debug information
 * How to look for the gdbserver (machine and port)
 * Optional gdb commands to execute before and after Seer connects to the gdbserver

--- a/src/resources/help/seergdb.hlp
+++ b/src/resources/help/seergdb.hlp
@@ -3,61 +3,74 @@ Usage: seergdb [LAUNCHOPTIONS] [MISCOPTIONS] executable [arguments ...]
 
 Seer - A gui frontend for gdb.
 
-  -h, --help                                        Displays help on commandline options.
-  -v, --version                                     Displays version information.
+  -h, --help                                                    Displays help on commandline options.
+  -v, --version                                                 Displays version information.
 
 
 Launch Options (pick one):
 
-  -r, --run <executable> <arguments>                Load the executable and run it.
+  -r, --run [--sym <symbolfile>] <executable> <arguments>       Load the executable and run it without breaking in "main".
 
-  -s, --start <executable> <arguments>              Load the executable, break in "main", and run it.
+                                                                'sym' is optional if the debugging info is in a separate file.
+                                                                'executable' is the name of the executable file.
 
-  --attach <pid> [<executable>]                     Attach to a locally running process.
-                                                    <executable> is the path to the executable to load.
-                                                    If <executable> is not given, use the executable stated
-                                                    by /proc/<pid>/exe
+  -s, --start [--sym <symbolfile>] <executable> <arguments>     Load the executable, break in "main", and run it.
 
-  --connect <medium> [--sym <symbolfile>]           Connect to an already running gdbserver (local or remote).
-                                                    Possible connection mediums are:
+                                                                'sym' is optional if the debugging info is in a separate file.
+                                                                'executable' is the name of the executable file.
 
-                                                        host:port
-                                                        /dev/<serialdev>
+  --attach <pid> [--sym <symbolfile>] [<executable>]            Attach to a locally running process.
 
-                                                    'sym' is optional if the debugging info is in a separate file.
+                                                                'pid' is the id of the running process.
+                                                                'sym' is optional if the debugging info is in a separate file.
+                                                                'executable' is the name of the executable file.  If 'executable' 
+                                                                is not given, use the executable stated by /proc/<pid>/exe.
 
-  --rr <trace-directory>                            Load a previously created RR trace session from 'trace-directory'.
+  --connect <medium> [--sym <symbolfile>] [<executable>]        Connect to an already running gdbserver (local or remote).
+                                                                Possible connection mediums are:
 
-  --core <corefile> <executable>                    Load a corefile.
+                                                                host:port
+                                                                /dev/<serialdev>
 
-  --project <project>                               Launch using a Seer project.
+                                                                'sym' is optional if the debugging info is in a separate file.
+                                                                'executable' is sometimes needed for embedded debugging (qemu).
+
+  --rr <trace-directory>                                        Load a previously created RR trace session from 'trace-directory'.
+
+  --core <corefile> [--sym <symbolfile>] <executable>           Load a corefile.
+
+                                                                'corefile' is the corefile to analyze.
+                                                                'sym' is optional if the debugging info is in a separate file.
+                                                                'executable' is the name of the executable file.
+
+  --project <project>                                           Launch using a Seer project.
 
 
 Arguments:
 
-  executable                                        The executable to debug. Needed for 'run', 'start', 'attach', and
-                                                    'core' run modes.
-  arguments                                         Arguments for the executable. Needed for 'run' and 'start'.
+  executable                                                    The executable to debug. Needed for 'run', 'start', 'attach', and
+                                                                'core' run modes. Optionally for 'connect'.
+  arguments                                                     Arguments for the executable. Needed for 'run' and 'start'.
 
 
 Misc Options:
 
-  --cwd, --working-dir <path>                       Set gdb's working directory path.
-  --sym, --symbol-file <symbolfilename>             Load symbols from a separate file than the executable.
-  --bl,  --break-load <filename>                    Load a previously saved breakpoints file. For 'run', 'start', or 'rr'.
-  --bf,  --break-function <function>                Set a breakpoint in a function/address. For 'run' or 'start'.
-  --bs,  --break-source <filename:lineno>           Set a breakpoint in a source file and line number. For 'run' or 'start'.
-                                                        eg:  --bs myprog.cpp:30
-  --sat, --show-assembly-tab <yes|no>               Show the Assembly Tab on Seer startup. For 'run' or 'start'.
-  --sar, --start-address-randomize <yes|no>         Randomize the program's starting address. For 'run' or 'start'.
-  --nsm, --non-stop-mode <yes|no>                   Continue to run other threads at breakpoints. For 'run' or 'start'.
+  --cwd, --working-dir <path>                                   Set gdb's working directory path.
+  --sym, --symbol-file <symbolfilename>                         Load symbols from a separate file than the executable.
+  --bl,  --break-load <filename>                                Load a previously saved breakpoints file. For 'run', 'start', or 'rr'.
+  --bf,  --break-function <function>                            Set a breakpoint in a function/address. For 'run' or 'start'.
+  --bs,  --break-source <filename:lineno>                       Set a breakpoint in a source file and line number. For 'run' or 'start'.
+                                                                    eg:  --bs myprog.cpp:30
+  --sat, --show-assembly-tab <yes|no>                           Show the Assembly Tab on Seer startup. For 'run' or 'start'.
+  --sar, --start-address-randomize <yes|no>                     Randomize the program's starting address. For 'run' or 'start'.
+  --nsm, --non-stop-mode <yes|no>                               Continue to run other threads at breakpoints. For 'run' or 'start'.
 
-  --gdb-program  <gdbprogram>                       Use a different gdb than what's set in Seer's configuration.
-  --gdb-arguments <gdbarguments>                    Use different gdb arguments than what's set in Seer's configuration.
+  --gdb-program  <gdbprogram>                                   Use a different gdb than what's set in Seer's configuration.
+  --gdb-arguments <gdbarguments>                                Use different gdb arguments than what's set in Seer's configuration.
 
-  --config                                          Launch with Seer's config dialog.
-                                                    Save settings with: 'Settings->Save Configuration'
+  --config                                                      Launch with Seer's config dialog.
+                                                                Save settings with: 'Settings->Save Configuration'
 
-  --xxx                                             Turn on internal Seer debugging messages.
+  --xxx                                                         Turn on internal Seer debugging messages.
 
 

--- a/tests/hellogdbserver/project.seer
+++ b/tests/hellogdbserver/project.seer
@@ -1,0 +1,18 @@
+{
+    "seerproject": {
+        "connectmode": {
+            "gdbserver": ":1234"
+        },
+        "executable": "/nas/erniep/Development/seer/tests/hellogdbserver/hellogdbserver",
+        "postgdbcommands": [
+            "b main",
+            "continue",
+            ""
+        ],
+        "pregdbcommands": [
+            ""
+        ],
+        "symbolfile": "/nas/erniep/Development/seer/tests/hellogdbserver/hellogdbserver_sym",
+        "workingdirectory": ""
+    }
+}


### PR DESCRIPTION
Some types of remote gdbserver (gdbstubs) will not load the executable. So Seer needs to do it itself. QEMU debugging is such a case. Note, simple use of Seer+gdbserver does not require this.