### PR TITLE
Increase process attach PID text input to 7 digits

### DIFF
--- a/src/SeerDebugDialog.ui
+++ b/src/SeerDebugDialog.ui
@@ -552,7 +552,7 @@
                <string>The process pid.</string>
               </property>
               <property name="inputMask">
-               <string>999999</string>
+               <string>9999999</string>
               </property>
               <property name="placeholderText">
                <string>pid</string>


### PR DESCRIPTION
Per `man 5 proc`, `PID_MAX_LIMIT` can be set up to 2^22 or 4194304 which is 7 digits