### PR TITLE
226 add an internal dark and light style

### DIFF
--- a/src/SeerMainWindow.cpp
+++ b/src/SeerMainWindow.cpp
@@ -36,6 +36,7 @@ SeerMainWindow::SeerMainWindow(QWidget* parent) : QMainWindow(parent) {
     // Add progress spin widget.
     QWidget* spacerWidget = new QWidget(this);
     spacerWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    spacerWidget->setStyleSheet("background-color:transparent"); // Need this for QToolBar StyleSheets to work.
     toolBar->addWidget(spacerWidget);
 
     _progressIndicator = new SeerProgressIndicator(this);

--- a/src/SeerRegisterValuesBrowserWidget.ui
+++ b/src/SeerRegisterValuesBrowserWidget.ui
@@ -15,15 +15,15 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
       <widget class="QLabel" name="registerFormatLabel">
        <property name="text">
         <string>Format</string>
        </property>
       </widget>
      </item>
-     <item>
+     <item row="0" column="1">
       <widget class="QComboBox" name="registerFormatComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -36,14 +36,41 @@
        </property>
       </widget>
      </item>
-     <item>
+     <item row="0" column="2">
+      <spacer name="horizontalSpacer_1">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>508</width>
+         <height>23</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="3">
+      <widget class="QToolButton" name="preferencesToolButton">
+       <property name="toolTip">
+        <string>Preferences</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="resource.qrc">
+         <normaloff>:/seer/resources/RelaxLightIcons/application-menu.svg</normaloff>:/seer/resources/RelaxLightIcons/application-menu.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
       <widget class="QLabel" name="registerProfileLabel">
        <property name="text">
         <string>Profile</string>
        </property>
       </widget>
      </item>
-     <item>
+     <item row="1" column="1">
       <widget class="QComboBox" name="registerProfileComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -59,32 +86,18 @@
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer">
+     <item row="1" column="2" colspan="2">
+      <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>250</width>
+         <width>538</width>
          <height>23</height>
         </size>
        </property>
       </spacer>
-     </item>
-     <item>
-      <widget class="QToolButton" name="preferencesToolButton">
-       <property name="toolTip">
-        <string>Preferences</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="resource.qrc">
-         <normaloff>:/seer/resources/RelaxLightIcons/application-menu.svg</normaloff>:/seer/resources/RelaxLightIcons/application-menu.svg</iconset>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>
@@ -127,6 +140,12 @@
    <header location="global">QIndexTreeWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>registerFormatComboBox</tabstop>
+  <tabstop>registerProfileComboBox</tabstop>
+  <tabstop>preferencesToolButton</tabstop>
+  <tabstop>registersTreeWidget</tabstop>
+ </tabstops>
  <resources>
   <include location="resource.qrc"/>
  </resources>

--- a/src/SeerThreadManagerWidget.ui
+++ b/src/SeerThreadManagerWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>914</width>
-    <height>536</height>
+    <width>398</width>
+    <height>520</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -51,6 +51,12 @@
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="schedulerLockingLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+       <horstretch>50</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Scheduler locking:</string>
      </property>
@@ -58,6 +64,12 @@
    </item>
    <item row="2" column="1">
     <widget class="QLabel" name="scheduleMultipleLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+       <horstretch>50</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -75,6 +87,12 @@
    </item>
    <item row="2" column="3">
     <widget class="QLabel" name="forkFollowsLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+       <horstretch>50</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Fork follows:</string>
      </property>
@@ -85,9 +103,12 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Ignored</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>564</width>
+       <width>0</width>
        <height>20</height>
       </size>
      </property>
@@ -164,9 +185,12 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Ignored</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>564</width>
+       <width>0</width>
        <height>20</height>
       </size>
      </property>

--- a/src/resources/qdarkstyle/ABOUT.md
+++ b/src/resources/qdarkstyle/ABOUT.md
@@ -13,4 +13,9 @@ And its license is here:
 
     Copyright (c) 2013-2019 Colin Duquesnoy
 
+QComboBox menus, with this style, look weird. There's a large "space" to the left of the menu text. It isn't
+resolved in the official QDarkStyleSheet project. This link shows a fix for the QComboBox entry in the
+"dark" and "light" css files. So I've applied it to my copy of the stylesheet.
+
+    https://github.com/ColinDuquesnoy/QDarkStyleSheet/issues/308#issuecomment-1661775924
 

--- a/src/resources/qdarkstyle/dark/darkstyle.qss
+++ b/src/resources/qdarkstyle/dark/darkstyle.qss
@@ -1272,20 +1272,6 @@ QComboBox:on {
   selection-background-color: #346792;
 }
 
-QComboBox::indicator {
-  border: none;
-  border-radius: 0;
-  background-color: transparent;
-  selection-background-color: transparent;
-  color: transparent;
-  selection-color: transparent;
-  /* Needed to remove indicator - fix #132 */
-}
-
-QComboBox::indicator:alternate {
-  background: #19232D;
-}
-
 QComboBox::item {
   /* Remove to fix #282, #285 and MR #288*/
   /*&:checked {

--- a/src/resources/qdarkstyle/light/lightstyle.qss
+++ b/src/resources/qdarkstyle/light/lightstyle.qss
@@ -1272,20 +1272,6 @@ QComboBox:on {
   selection-background-color: #9FCBFF;
 }
 
-QComboBox::indicator {
-  border: none;
-  border-radius: 0;
-  background-color: transparent;
-  selection-background-color: transparent;
-  color: transparent;
-  selection-color: transparent;
-  /* Needed to remove indicator - fix #132 */
-}
-
-QComboBox::indicator:alternate {
-  background: #FAFAFA;
-}
-
 QComboBox::item {
   /* Remove to fix #282, #285 and MR #288*/
   /*&:checked {


### PR DESCRIPTION
This fixes some gui issues with QDarkStyle.   

- QTabBar has the wrong background color between the left QTabButtons and the widget on the far right.
- QDarkStyle messes up some QComboBox widgets and makes the menu entry larger than it needs to.
- The left and right Seer panels can be made smaller. Helps those who don't have large terminals.
