### PR TITLE
Add openSUSE Tumbleweed install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Available through the following package managers:
 
     pamac install seer
 
+### zypper (openSUSE Tumbleweed)
+
+    zypper install seergdb
+
 Install from source
 ---------
 (Recommended) Seer can be built with Qt6 by following the instructions below.


### PR DESCRIPTION
Hi @epasveer,

As we've added this package to openSUSE Tumbleweed, I think it'd be useful to have the install instructions for that particular distribution on the README.

Let me know, thank you!