### PR TITLE
Fixed setting/saving font settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Show stack as a hex dump, with options to view as short, int, long, ascii, ...
 * The "go to address" in the Assembly view now works if address it outside
   current assembly view.
+* Fixed regression when setting/saving the editor font setting.
 
 ## [2.4] - 2024-03-18
 * Changed main icon to a more license friendly one.

--- a/src/SeerMainWindow.cpp
+++ b/src/SeerMainWindow.cpp
@@ -717,6 +717,7 @@ void SeerMainWindow::handleSettingsConfiguration () {
     gdbWidget->setDprintfStyle(dlg.dprintfStyle());
     gdbWidget->setDprintfFunction(dlg.dprintfFunction());
     gdbWidget->setDprintfChannel(dlg.dprintfChannel());
+    gdbWidget->editorManager()->setEditorFont(dlg.editorFont());
     gdbWidget->editorManager()->setEditorTabSize(dlg.editorTabSize());
     gdbWidget->editorManager()->setEditorHighlighterSettings(dlg.editorHighlighterSettings());
     gdbWidget->editorManager()->setEditorHighlighterEnabled(dlg.editorHighlighterEnabled());


### PR DESCRIPTION
Fixed.

A regression. I must have deleted the call to set the new font in the EditorManager.