### PR TITLE
Fix bug with expanding tree if there are no children (displaying simple variable types)

### DIFF
--- a/src/SeerStructVisualizerWidget.cpp
+++ b/src/SeerStructVisualizerWidget.cpp
@@ -103,8 +103,10 @@ void SeerStructVisualizerWidget::handleText (const QString& text) {
             // Populate the tree.
             handleItemCreate(topItem, value_text);
 
-            // For now, always expand everything.
-            variableTreeWidget->expandAll();
+            // Expand everything if there are children.
+            if (topItem->childCount() > 0) {
+                variableTreeWidget->expandAll();
+            }
         }
 
 


### PR DESCRIPTION
For simple variable types (ints, floats, etc.) there were no sub children in the tree widget view. The 'expandAll' call would fail and result in a segfault (Qt bug?).

The fix is to only call 'expandAll' if there are sub children, as in the case of structures.
