### PR TITLE
make compatible with CMake 4.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(seergdb VERSION 2.6.0 LANGUAGES CXX)
 


### PR DESCRIPTION
CMake 3.5.0 was released about 9 years ago, so compatibility with older versions is probably not an issue

closes #304 