### PR TITLE
allow space before parenthesis at end of functions

### DIFF
--- a/src/SeerCppSourceHighlighter.cpp
+++ b/src/SeerCppSourceHighlighter.cpp
@@ -94,7 +94,7 @@ void SeerCppSourceHighlighter::setHighlighterSettings (const SeerHighlighterSett
     _highlightingRules.append(rule);
 
     // Set function format and expression.
-    rule.pattern = QRegularExpression(QStringLiteral("\\b[A-Za-z0-9_]+(?=\\()"));
+    rule.pattern = QRegularExpression(QStringLiteral("\\b[A-Za-z0-9_]+(?=\\s*\\()"));
     rule.format = _functionFormat;
     _highlightingRules.append(rule);
 


### PR DESCRIPTION
I noticed that functions are not highlighted if some spaces lie between the function name and the open parenthesis.
This simple fix fixes the problem.