### PR TITLE
SeerDebugDialog: offer to open '*.core' core dump files as well

### DIFF
--- a/src/SeerDebugDialog.cpp
+++ b/src/SeerDebugDialog.cpp
@@ -447,7 +447,7 @@ void SeerDebugDialog::handleLoadBreakpointsFilenameToolButton () {
 
 void SeerDebugDialog::handleLoadCoreFilenameToolButton () {
 
-    QString name = QFileDialog::getOpenFileName(this, "Select a core file to debug.", coreFilename(), "Core Files (core core.*)", nullptr, QFileDialog::DontUseNativeDialog);
+    QString name = QFileDialog::getOpenFileName(this, "Select a core file to debug.", coreFilename(), "Core Files (core core.* *.core)", nullptr, QFileDialog::DontUseNativeDialog);
 
     if (name != "") {
         setCoreFilename(name);


### PR DESCRIPTION
Core dumps on OpenBSD are named like that.