### PR TITLE
Don't collapse items when searching.

### DIFF
--- a/src/SeerSourceBrowserWidget.cpp
+++ b/src/SeerSourceBrowserWidget.cpp
@@ -146,18 +146,21 @@ void SeerSourceBrowserWidget::handleText (const QString& text) {
             }
         }
 
+        // Always expand the source items. Expanding the other
+        // items are under the user's control.
         _sourceFilesItems->setExpanded(true);
-        _headerFilesItems->setExpanded(false);
-        _miscFilesItems->setExpanded(false);
 
     }else{
         // Ignore others.
     }
 
+    // Sort each item separately.
+    _sourceFilesItems->sortChildren(0, Qt::AscendingOrder);
+    _headerFilesItems->sortChildren(0, Qt::AscendingOrder);
+    _miscFilesItems->sortChildren(0, Qt::AscendingOrder);
+
     sourceTreeWidget->resizeColumnToContents(0);
     sourceTreeWidget->resizeColumnToContents(1);
-    sourceTreeWidget->sortByColumn(0, Qt::AscendingOrder);
-    sourceTreeWidget->setSortingEnabled(true);
 
     sourceSearchLineEdit->clear();
 
@@ -262,9 +265,9 @@ void SeerSourceBrowserWidget::handleSearchLineEdit (const QString& text) {
             }
         }
 
+        // Always expand the source items. Expanding the other
+        // items are under the user's control.
         _sourceFilesItems->setExpanded(true);
-        _headerFilesItems->setExpanded(false);
-        _miscFilesItems->setExpanded(false);
 
         //qDebug() << text << matches.size();
     }


### PR DESCRIPTION
Fixed.

Opened trees for the Source Browser are no longer closed when searching.

Also, I organized the 3 trees by:  Source, Headers, Misc.
