### PR TITLE
Elaborate gdb variable output

### DIFF
--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -1168,6 +1168,9 @@ void SeerGdbWidget::handleGdbRunExecutable (const QString& breakMode, bool loadS
             handleGdbBreakpointsInsert(executableBreakpointSourceName());
         }
 
+        // Elaborate gdb variable output
+        handleGdbCommand("set print repeats unlimited");
+
         // Run any 'post' commands after program is loaded.
         handleGdbExecutablePostCommands();
 
@@ -1290,6 +1293,9 @@ void SeerGdbWidget::handleGdbAttachExecutable (bool loadSessionBreakpoints) {
             handleGdbBreakpointsInsert(executableBreakpointSourceName());
         }
 
+        // Elaborate gdb variable output
+        handleGdbCommand("set print repeats unlimited");
+
         // Run any 'post' commands after program is loaded.
         handleGdbExecutablePostCommands();
 
@@ -1400,6 +1406,9 @@ void SeerGdbWidget::handleGdbConnectExecutable (bool loadSessionBreakpoints) {
         if (executableBreakpointSourceName() != "") {
             handleGdbBreakpointsInsert(executableBreakpointSourceName());
         }
+
+        // Elaborate gdb variable output
+        handleGdbCommand("set print repeats unlimited");
 
         // Run any 'post' commands after program is loaded.
         handleGdbExecutablePostCommands();
@@ -1512,6 +1521,9 @@ void SeerGdbWidget::handleGdbRRExecutable (bool loadSessionBreakpoints) {
             handleGdbBreakpointsInsert(executableBreakpointSourceName());
         }
 
+        // Elaborate gdb variable output
+        handleGdbCommand("set print repeats unlimited");
+
         // Run any 'post' commands after program is loaded.
         handleGdbExecutablePostCommands();
 
@@ -1607,6 +1619,9 @@ void SeerGdbWidget::handleGdbCoreFileExecutable () {
 
         // Load the executable's core file.
         handleGdbCommand(QString("-target-select core %1").arg(executableCoreFilename()));
+
+        // Elaborate gdb variable output
+        handleGdbCommand("set print repeats unlimited");
 
         // Run any 'post' commands after program is loaded.
         handleGdbExecutablePostCommands();


### PR DESCRIPTION
In some cases, when GDB encounters a struct that contains an array, its output will show something like:
`
id = 2, b = \"000hildTest 2000377177000000P327377377377177\", '000' <repeats 11 times>, \"hildTest 2000377177000000001", '0' <repeats 21 times>, "x327377377377177000000004", '0' <repeats 21 times>, "test\", '000' <repeats 20 times>, \"240327377377\", child = {childId = -9864, childString = \"\"}
`
It was the <repeats 21 times> message that hindered developers in parsing GDB output.
It would be better to print the full variable contents instead of suppressing them.
Luckily, I found that the command `set print repeats unlimited` helps us achieve this
