### PR TITLE
Update Cursor margin

### DIFF
--- a/src/SeerPlainTextEdit.h
+++ b/src/SeerPlainTextEdit.h
@@ -27,8 +27,10 @@ class SeerPlainTextEdit : public QPlainTextEdit {
 
     private slots:
         void                    blinkCursor                 ();
+        void                    handleCursorPositionChanged ();
 
     private:
+        constexpr static int    CURSOR_WIDTH = 2;
         QTimer*                 _cursorTimer;
         bool                    _cursorVisible;
 };


### PR DESCRIPTION
Unlike VS Code, Seer doesn’t have a "cursor block", so it’s harder to see and navigate the current line of cursor
Therefore, I’d like to add a cursor margin so users can more easily identify the cursor’s position.
Furthermore, I noticed that the cursor doesn’t **blink** initially and its size is quite small. I’d like to fix that as well. 

"cursor block" also moves when stepping through the code, please give it a try
[Screencast from 2025-11-27 11:13:31 AM.webm](https://github.com/user-attachments/assets/0817b5d2-65d1-497c-962f-a9aee0c0bfc0)
