### PR TITLE
fix recursive painting

### DIFF
--- a/src/SeerEditorManagerWidget.cpp
+++ b/src/SeerEditorManagerWidget.cpp
@@ -632,6 +632,8 @@ void SeerEditorManagerWidget::handleText (const QString& text) {
             // Parse through the frame list and set the current lines that are in the frame list.
             QStringList frame_list = Seer::parse(newtext, "frame=", '{', '}', false);
 
+            SeerEditorManagerEntries::iterator i_later=endEntry();
+            int lineToPrintLater = -1;
             for ( const auto& frame_text : frame_list  ) {
                 QString level_text    = Seer::parseFirst(frame_text, "level=",    '"', '"', false);
                 QString addr_text     = Seer::parseFirst(frame_text, "addr=",     '"', '"', false);
@@ -644,9 +646,18 @@ void SeerEditorManagerWidget::handleText (const QString& text) {
                 SeerEditorManagerEntries::iterator i = findEntry(fullname_text);
                 SeerEditorManagerEntries::iterator e = endEntry();
 
+                if (level_text.toInt() == 0)    // if current line level = 0, save command and paint it later, fix recursive painting
+                {
+                    i_later = i;
+                    lineToPrintLater = line_text.toInt();
+                    continue;
+                }
                 if (i != e) {
                     i->widget->sourceArea()->addCurrentLine(line_text.toInt(), level_text.toInt());
                 }
+            }
+            if (i_later != endEntry() && lineToPrintLater != -1) {
+                i_later->widget->sourceArea()->addCurrentLine(lineToPrintLater, 0);
             }
         }
 


### PR DESCRIPTION
The reason I want to add a recursive test is this:
I set a breakpoint in the `factorial` function at the line where it calls itself (as shown in the image).
Now, looking at the backtrace, you can see that `factorial` is called several times.
But at line 94, the line color is gray instead of yellow because frame level 0 is overwritten by levels 1 and 2, causing it to turn gray.

<img width="1545" height="531" alt="Screenshot from 2025-11-30 11-59-34" src="https://github.com/user-attachments/assets/a1a04c11-999b-49f8-b5f8-91b4bdb17bfe" />
