### PR TITLE
Fix fail to run gdb

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -308,7 +308,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 # Handle default gdb binary name and location.
 # -DCONFIG_SEER_GDB_NAME=/app/bin/gdb
 if(NOT DEFINED CONFIG_SEER_GDB_NAME)
-    set(CONFIG_SEER_GDB_NAME"/usr/bin/gdb")
+    set(CONFIG_SEER_GDB_NAME "/usr/bin/gdb")
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE


### PR DESCRIPTION
In Cmakelist, command set(CONFIG_SEER_GDB_NAME"/usr/bin/gdb") doesn't seperate  CONFIG_SEER_GDB_NAME and "/usr/bin/gdb", causing seer failed to start gdb
<img width="1475" height="769" alt="image" src="https://github.com/user-attachments/assets/f26d6194-07f5-424f-b5fa-60a8196a1dbc" />
