### PR TITLE
Erase color of level 0 backtrace when target is running

### DIFF
--- a/src/SeerEditorManagerWidget.cpp
+++ b/src/SeerEditorManagerWidget.cpp
@@ -631,7 +631,7 @@ void SeerEditorManagerWidget::handleText (const QString& text) {
 
             // Parse through the frame list and set the current lines that are in the frame list.
             QStringList frame_list = Seer::parse(newtext, "frame=", '{', '}', false);
-
+            _lastFrameList = frame_list;
             SeerEditorManagerEntries::iterator i_later=endEntry();
             int lineToPrintLater = -1;
             for ( const auto& frame_text : frame_list  ) {
@@ -732,7 +732,22 @@ void SeerEditorManagerWidget::handleText (const QString& text) {
             static_cast<SeerEditorWidgetSource*>(w)->sourceArea()->handleText(text);
         }
 
-    }else{
+    }else if (text.startsWith("*running")) {
+        // target / program is running, should erase 'yellow' color is for the current line 
+        // _lastFrameList is invoked to erase previously "colored" line
+        for ( const auto& frame_text : _lastFrameList  ) {
+            QString fullname_text = Seer::parseFirst(frame_text, "fullname=", '"', '"', false);
+            QString line_text     = Seer::parseFirst(frame_text, "line=",     '"', '"', false);
+
+            SeerEditorManagerEntries::iterator i = findEntry(fullname_text);
+            SeerEditorManagerEntries::iterator e = endEntry();
+
+            if (i != e) {
+                i->widget->sourceArea()->eraseColorCurrentLine(line_text.toInt());
+            }
+        }
+    }
+    else{
         // Ignore others.
         return;
     }

--- a/src/SeerEditorManagerWidget.h
+++ b/src/SeerEditorManagerWidget.h
@@ -155,5 +155,6 @@ class SeerEditorManagerWidget : public QWidget, protected Ui::SeerEditorManagerW
         bool                                            _showOpcodeColumn;
         bool                                            _showSourceLines;
         bool                                            _notifyAssemblyTabShown;
+        QStringList                                     _lastFrameList;         // variable for saving previous backtrace
 };
 

--- a/src/SeerEditorWidgetSource.h
+++ b/src/SeerEditorWidgetSource.h
@@ -97,6 +97,7 @@ class SeerEditorWidgetSourceArea : public SeerPlainTextEdit {
         void                                        setExternalEditorCommand            (const QString& externalEditorCommand);
         const QString&                              externalEditorCommand               ();
 
+        void                                        eraseColorCurrentLine               (int lineno);
     signals:
         void                                        insertBreakpoint                    (QString breakpoint);
         void                                        insertPrintpoint                    (QString type, QString function, QString channel, QString parameters);

--- a/src/SeerEditorWidgetSourceAreas.cpp
+++ b/src/SeerEditorWidgetSourceAreas.cpp
@@ -1669,6 +1669,32 @@ const QString& SeerEditorWidgetSourceArea::externalEditorCommand () {
     return _externalEditorCommand;
 }
 
+void SeerEditorWidgetSourceArea::eraseColorCurrentLine (int lineno) {
+
+    // Erase color of this line
+    QTextCharFormat lineFormat;
+    lineFormat = highlighterSettings().get("Text");
+
+    // Create a selection at the cursor.
+    QTextBlock  block  = document()->findBlockByLineNumber(lineno-1);
+    QTextCursor cursor = textCursor();
+
+    cursor.setPosition(block.position());
+
+    QTextEdit::ExtraSelection selection;
+    selection.format.setForeground(lineFormat.foreground());
+    selection.format.setBackground(lineFormat.background());
+    selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+    selection.cursor = cursor;
+    selection.cursor.clearSelection();
+
+    // Add it to the extra selection list.
+    _currentLinesExtraSelections.append(selection);
+
+    // Refresh all the extra selections.
+    refreshExtraSelections();
+}
+
 void SeerEditorWidgetSourceArea::handleText (const QString& text) {
 
     if (text.startsWith("*stopped")) {


### PR DESCRIPTION
When a program is halted or stopped, Seer highlights the level 0 backtrace line in yellow.
But when the program is running, that line is still yellow. I think we should revert this color whenever the target is running.
Before the fix:
<img width="1800" height="425" alt="image" src="https://github.com/user-attachments/assets/e01301c0-5a2a-4ea3-9c5c-85ff5165dd44" />

Fixed:

<img width="1800" height="425" alt="image" src="https://github.com/user-attachments/assets/79be07b1-5e6e-4753-8a00-f08458c0a8a2" />
