### PR TITLE
Add feature: Mouse navigation

### DIFF
--- a/src/SeerEditorManagerWidget.h
+++ b/src/SeerEditorManagerWidget.h
@@ -103,6 +103,10 @@ class SeerEditorManagerWidget : public QWidget, protected Ui::SeerEditorManagerW
         void                                            handleAssemblyConfigChanged         ();
         void                                            handleSessionTerminated             ();
         void                                            handleGdbStateChanged               ();
+        void                                            handleAddToMouseNavigation          (const SeerEditorWidgetSourceArea::SeerCurrentFile& currentFile);
+
+    protected:
+        void                                            mousePressEvent                     (QMouseEvent *event) override;
 
     private slots:
         void                                            handleFileOpenToolButtonClicked     ();
@@ -144,6 +148,7 @@ class SeerEditorManagerWidget : public QWidget, protected Ui::SeerEditorManagerW
         SeerEditorWidgetAssembly*                       createAssemblyWidgetTab             ();
         void                                            deleteAssemblyWidgetTab             ();
         void                                            handleOpenFileWithDetails           (const QString& file, const QString& fullname, int cursorRow, int cursorCol, int firstDisplayLine);
+        void                                            handleOpenForwardBackward           (const SeerEditorWidgetSourceArea::SeerCurrentFile& fileInfo);
 
         SeerEditorManagerEntries                        _entries;
         SeerHighlighterSettings                         _editorHighlighterSettings;
@@ -167,5 +172,8 @@ class SeerEditorManagerWidget : public QWidget, protected Ui::SeerEditorManagerW
 
         // list of recently closed files (Ctrl + Shift + T)
         QStack<SeerEditorWidgetSourceArea::SeerCurrentFile>                     _stackClosedFiles;
+        // list of cursor positions for mouse navigation (back/forward)
+        QList<SeerEditorWidgetSourceArea::SeerCurrentFile>                      _listForwardFiles;
+        int                                             _forwardFilesIndex = -1;
 };
 

--- a/src/SeerEditorWidgetSource.h
+++ b/src/SeerEditorWidgetSource.h
@@ -140,6 +140,7 @@ class SeerEditorWidgetSourceArea : public SeerPlainTextEdit {
         void                                        showAlternateBar                    (bool flag);
         void                                        showReloadBar                       (bool flag);
         void                                        highlighterSettingsChanged          ();
+        void                                        addToMouseNavigation                (const SeerCurrentFile& currentFile);
 
     public slots:
         void                                        handleText                          (const QString& text);
@@ -154,6 +155,7 @@ class SeerEditorWidgetSourceArea : public SeerPlainTextEdit {
         bool                                        event                               (QEvent* event);
         void                                        showExpressionTooltip               ();
         void                                        hideExpressionTooltip               ();
+        void                                        mousePressEvent                     (QMouseEvent *event) override;
 
     private slots:
         void                                        refreshExtraSelections              ();
@@ -163,6 +165,7 @@ class SeerEditorWidgetSourceArea : public SeerPlainTextEdit {
         void                                        updateBreakPointArea                (const QRect& rect, int dy);
 
     private:
+        void                                        handleCursorPositionChanged         ();
         QString                                     _fullname;
         QString                                     _file;
         QString                                     _alternateDirectory;
@@ -194,6 +197,8 @@ class SeerEditorWidgetSourceArea : public SeerPlainTextEdit {
 
         int                                         _sourceTabSize;
         QString                                     _externalEditorCommand;
+
+        int                                         _ignoreThumbMouseEvent = 0;
 };
 
 class SeerEditorWidgetSourceLineNumberArea : public QWidget {


### PR DESCRIPTION
Another handy feature of vscode that I'd like to integrate to Seer: Navigate History (Back/Forward)
Use 2 button on Thumb mouse to try
