### PR TITLE
Fix typo in SeerGdbWidget.cpp

### DIFF
--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -3082,7 +3082,7 @@ void SeerGdbWidget::handleGdbProcessErrored (QProcess::ProcessError errorStatus)
         QMessageBox::warning(this, "Seer",
                                    QString("Unable to launch the GDB program.\n\n") +
                                    QString("'%1 %2'").arg(_gdbProcess->program()).arg(_gdbProcess->arguments().join(' ')) + "\n\n" +
-                                   QString("Error status=%1)").arg(errorStatus),
+                                   QString("Error status=%1").arg(errorStatus),
                                    QMessageBox::Ok);
     }
 }


### PR DESCRIPTION
Removes a spare parenthesis from "Error status=[status])" when a GDB program fails to launch.