### PR TITLE
SeerMainWindow: Change action buttons when status changed

### DIFF
--- a/src/SeerMainWindow.h
+++ b/src/SeerMainWindow.h
@@ -105,6 +105,9 @@ class SeerMainWindow : public QMainWindow, protected Ui::SeerMainWindowForm {
         void                        handleStyleMenuChanged                  ();
         void                        handleShowMessage                       (QString message, int time);
         void                        handleGdbStateChanged                   ();
+        void                        handleGdbTargetRunning                  ();
+        void                        handleGdbTargetInterrupt                ();
+        void                        handleStatusChanged                     (QString message);
 
     protected:
         void                        writeSettings                           ();


### PR DESCRIPTION
I see that many other IDEs disable action buttons when a program is running or halted.
I believe Seer should do the same. This could also prevent potential bugs.
[Screencast from 01-25-2026 11:13:33 PM.webm](https://github.com/user-attachments/assets/8039e1d1-aa3b-46a8-9ade-46191b15d1d2)
