### PR TITLE
write config: don't require to click two dialogs away, just show a transient message box instead

### DIFF
--- a/src/SeerMainWindow.cpp
+++ b/src/SeerMainWindow.cpp
@@ -834,19 +834,13 @@ void SeerMainWindow::handleSettingsConfiguration () {
 }
 
 void SeerMainWindow::handleSettingsSaveConfiguration () {
-
-    int result = QMessageBox::warning(this, "Seer - Settings",
-                                      QString("Write the configuration settings?"),
-                                      QMessageBox::Ok|QMessageBox::Cancel, QMessageBox::Cancel);
-
-    if (result == QMessageBox::Cancel) {
-        return;
-    }
-
     writeConfigSettings();
     gdbWidget->writeSettings();
 
-    QMessageBox::information(this, "Seer", "Saved.");
+    QMessageBox m(QMessageBox::Information, "Seer", "Configuration saved!");
+    m.setStandardButtons(QMessageBox::NoButton);
+    QTimer::singleShot(1000, &m, SLOT(hide()));
+    m.exec();
 }
 
 void SeerMainWindow::handleHelpAbout () {


### PR DESCRIPTION
There's a reason you designed it as you did, so I understand if you reject my proposal. But when I want to save the config, I don't see a need to confirm twice. It's enough to tell me that my order was understood and processed.
