### PR TITLE
Update build STM32 build instruction

### DIFF
--- a/tests/stm32f1_blink/Docker/Dockerfile
+++ b/tests/stm32f1_blink/Docker/Dockerfile
@@ -1,0 +1,46 @@
+# =============================================================================
+# STM32 Firmware Build Environment
+# =============================================================================
+
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=UTC \
+    PATH="/opt/arm-gnu-toolchain/bin:${PATH}"
+
+# ----------------------------------------------------------------------
+# 1. Install system packages
+# ----------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl xz-utils \
+    make cmake ninja-build git \
+    python3 python3-venv libncurses5 \
+    dfu-util stlink-tools sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# ----------------------------------------------------------------------
+# 2. Install Arm GNU Toolchain
+# ----------------------------------------------------------------------
+RUN curl -L -o /tmp/tc.tar.xz \
+    https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi.tar.xz && \
+    mkdir -p /opt/arm-gnu-toolchain && \
+    tar -xJf /tmp/tc.tar.xz -C /opt/arm-gnu-toolchain --strip-components=1 && \
+    rm -f /tmp/tc.tar.xz
+
+# ----------------------------------------------------------------------
+# 3. Create user + permissions
+# ----------------------------------------------------------------------
+RUN useradd -m -s /bin/bash -u 1000 developer && \
+    echo "developer ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/developer && \
+    chmod 0440 /etc/sudoers.d/developer && \
+    mkdir -p /workdir && chown developer:developer /workdir && \
+    echo 'export PATH="/opt/arm-gnu-toolchain/bin:$PATH"' >> /home/developer/.bashrc
+
+USER developer
+WORKDIR /workdir
+
+COPY --chown=developer:developer ./entrypoint.sh /opt/entrypoint.sh
+RUN chmod +x /opt/entrypoint.sh
+
+ENTRYPOINT ["/opt/entrypoint.sh"]
+CMD ["bash"]

--- a/tests/stm32f1_blink/Docker/entrypoint.sh
+++ b/tests/stm32f1_blink/Docker/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+ 
+USER_NAME=developer
+GROUP_NAME=scom-group
+ 
+# Verification that the user is not already created. (For bug in gitlab CI where the entrypoint is run multiple times)
+if id "${USER_NAME}" >/dev/null 2>&1; then
+    echo "user ${USER_NAME} found"
+else
+    # User creation
+    if [ -d "/workdir" ]; then
+        USER_ID=$(stat -c %u /workdir/)
+        GROUP_ID=$(stat -c %g /workdir/)
+ 
+        echo "Init ${USER_NAME} with uid: ${USER_ID} & gid; ${GROUP_ID}"
+        sudo groupadd -g "${GROUP_ID}" "${GROUP_NAME}"
+        sudo useradd ${USER_NAME} -u "${USER_ID}" -g "${GROUP_ID}" -ml -s /bin/bash
+    else
+        echo "Error: Directory /workdir does not exists. Unable to set the container UID & GID."
+        sudo useradd ${USER_NAME} -ml -s /bin/bash
+    fi
+fi
+ 
+# sudo usermod -G sudo ${USER_NAME}
+ 
+if [ -d "/host" ]; then
+    # shellcheck disable=SC2045
+    for ITEM in $(ls -A /host/); do
+        if [ -e "/home/${USER_NAME}/${ITEM}" ]; then
+            echo "File $ITEM already present. Overwriting it with the one found in /host."
+        fi
+        sudo ln -svf "/host/${ITEM}" "/home/${USER_NAME}/${ITEM}"
+        sudo chown "${USER_NAME}:${GROUP_NAME}" "/home/${USER_NAME}/${ITEM}"
+    done
+fi
+ 
+sudo su "${USER_NAME}"

--- a/tests/stm32f1_blink/Makefile
+++ b/tests/stm32f1_blink/Makefile
@@ -119,6 +119,20 @@ flash: $(BUILD_DIR)/$(TARGET).elf
 	openocd -f $(JLINK_CFG) -f $(OPENOCD_TARGET) \
 		-c "program $< verify reset exit"
 
+build_docker:
+	docker build -t docker_stm32 Docker
+
+docker:
+	docker run --rm -it --user $(id -u):$(id -g) \
+	--name "docker_build_stm32" \
+	--mount type=bind,source="${HOME}/.bash_history",target=/home/user/.bash_history \
+	--mount type=bind,source="${HOME}/.bashrc",target=/home/user/.bashrc \
+	--mount type=bind,source="${HOME}/.gitconfig",target=/home/user/.gitconfig \
+	--mount type=bind,source="${HOME}/.ssh",target=/home/user/.ssh \
+	--mount type=bind,source="${PWD}",target=/workdir \
+	--workdir=/workdir \
+	docker_stm32
+
 clean:
 	@echo "[RM]      $(BUILD_DIR)"; $(RM) -r $(BUILD_DIR)
 

--- a/tests/stm32f1_blink/README.md
+++ b/tests/stm32f1_blink/README.md
@@ -5,13 +5,17 @@ This test for quick build and testing seer using stm32 smart v2.0j board, or ess
 + stm32 smart v2.0j board
 + J-Link, or you can use other hardware debugger if you're capable of doing
 # Prerequisite
-Install gdb-multiarch:
-```sudo apt install gcc-arm-none-eabi```
-and install openocd and openocd driver for J-link:
-```./install_openocd.sh```
-# Build 
-Connect hardware debugger to stm32f1 board
-run `./build.sh`, it will pull remote library, build and flash image to stm32f1 automatically for your
++ Install docker, makefile
++ Install openocd: `./install_openocd.sh`
+# Instruction
++ Build STM32 firmware: (run in docker container)
+	+ Build docker image: `make build_docker`
+	+ Run docker image: `make docker`
+	+ Build image in docker: `./build.sh` <br>
+Final image is located at: stm32f1_blink/build/main.elf<br>
++ Flash image to STM32 board: (run in host terminal)
+	+ make flash JLINK_CFG=interface/jlink.cfg <br>
+You'll see the STM32 led blinks
 # Troubleshoot:
 + Install Jlink driver
 + Proper connection

--- a/tests/stm32f1_blink/build.sh
+++ b/tests/stm32f1_blink/build.sh
@@ -4,10 +4,5 @@ git clone https://github.com/STMicroelectronics/STM32CubeF1.git vendor
 cd vendor
 git submodule update --init --recursive
 cd ..
-# install package
-sudo apt install gcc-arm-none-eabi
 # make
 make
-# make flash, assume that openocd is installed by running install_openocd.sh
-make flash JLINK_CFG=${PWD}/../openocd/tcl/interface/jlink.cfg
-


### PR DESCRIPTION
Instruction:
Go to tests/stm32f1_blink

1. Build docker: `make build_docker`
2. Run docker image: `make docker`
3. Build STM32 image (inside docker): .`/build.sh`
Final image is located at: `stm32f1_blink/build/main.elf`
4. As you're using stm32 bluepill board, which is only flashed with SWD instead of JTAG peripheral by default on Jlink. Change file `/usr/local/share/openocd/scripts/interface/jlink.cfg` (with **sudo permission**):
```
# SPDX-License-Identifier: GPL-2.0-or-later

#
# SEGGER J-Link
#
# http://www.segger.com/jlink.html
#

adapter driver jlink
transport select swd
# The serial number can be used to select a specific device in case more than
# one is connected to the host.
#
# Example: Select J-Link with serial number 123456789
#
# adapter serial 123456789
```
5. Flash to stm32: `make flash JLINK_CFG=interface/jlink.cfg`
You'll se STM32's led blinks