### PR TITLE
Delete OpenOCD terminal before terminating debug session

### DIFF
--- a/src/SeerOpenOCDWidget.cpp
+++ b/src/SeerOpenOCDWidget.cpp
@@ -52,6 +52,10 @@ void SeerOpenOCDWidget::terminate ()
             _openocdProcess->waitForFinished(500);          // Brief wait to ensure kill completes
         }
     }
+    if (_openocdLogsTabWidget) {
+        delete _openocdLogsTabWidget;
+        _openocdLogsTabWidget = nullptr;
+    }
 }
 
 bool SeerOpenOCDWidget::isOpenocdRunning ()
@@ -158,12 +162,6 @@ void SeerOpenOCDWidget::createOpenOCDConsole (QDetachTabWidget* parent)
 SeerLogWidget* SeerOpenOCDWidget::openocdConsole()
 {
     return _openocdLogsTabWidget;
-}
-
-void SeerOpenOCDWidget::killConsole ()
-{
-    delete _openocdLogsTabWidget;
-    _openocdLogsTabWidget = nullptr;
 }
 
 void SeerOpenOCDWidget::setConsoleVisible (bool flag)

--- a/src/SeerOpenOCDWidget.h
+++ b/src/SeerOpenOCDWidget.h
@@ -24,7 +24,6 @@ class SeerOpenOCDWidget: public SeerLogWidget{
         qint64                              telnetRunCmd                    (const QString &command);
         // Create & kill Console displaying OpenOCD process logs
         void                                createOpenOCDConsole            (QDetachTabWidget* parent);
-        void                                killConsole                     ();
         void                                setConsoleVisible               (bool flag);
         // Getters & Setters
         SeerLogWidget*                      openocdConsole                  ();


### PR DESCRIPTION
<img width="694" height="152" alt="Screenshot from 2026-05-01 16-23-19" src="https://github.com/user-attachments/assets/5e24d7b0-9936-486f-beae-95cb39fd604a" />

Currently, when terminating a openocd session and starting a new one, the openocd terminal doesn't close
This MR will fix it