### PR TITLE
OpenOCD: Let gdbLiveWatch handles Goto Definition

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ if(${QTVERSION} STREQUAL "QT6")
     find_package(Qt6 COMPONENTS REQUIRED Svg)
     find_package(Qt6 COMPONENTS REQUIRED OpenGL)
     find_package(Qt6 COMPONENTS REQUIRED Network)
+    find_package(Qt6 COMPONENTS REQUIRED SerialPort)
 
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -167,6 +168,7 @@ set(HEADER_FILES
     SeerMacroToolButton.h
     SeerOpenOCDWidget.h
     SeerOpenocdConfigPage.h
+    SeerOpenOCDDebugOnInit.h
     )
 
 # Define the source location of source files
@@ -283,6 +285,7 @@ set(SOURCE_FILES
     SeerMacroToolButton.cpp
     SeerOpenOCDWidget.cpp
     SeerOpenocdConfigPage.cpp
+    SeerOpenOCDDebugOnInit.cpp
     seergdb.cpp
     )
 
@@ -313,7 +316,7 @@ add_executable(${PROJECT_NAME} ${SYSTEM_TYPE} ${SOURCE_FILES})
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 
 if(${QTVERSION} STREQUAL "QT6")
-    target_link_libraries(${PROJECT_NAME} Qt6::Widgets Qt6::Gui Qt6::Core Qt6::PrintSupport Qt6::Charts Qt6::Svg Qt6::OpenGL Qt6::Network)
+    target_link_libraries(${PROJECT_NAME} Qt6::Widgets Qt6::Gui Qt6::Core Qt6::PrintSupport Qt6::Charts Qt6::Svg Qt6::OpenGL Qt6::Network Qt6::SerialPort)
 elseif(${QTVERSION} STREQUAL "QT5")
     target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::Gui Qt5::Core Qt5::PrintSupport Qt5::Charts)
 endif()

--- a/src/SeerDebugDialog.cpp
+++ b/src/SeerDebugDialog.cpp
@@ -695,7 +695,7 @@ QJsonDocument SeerDebugDialog::makeJsonDoc() const {
         QJsonObject modeJson;
         // Main Tab
         modeJson["openocdExe"]                  = executableOpenOCDPathLineEdit->text();
-        modeJson["openocdCommand"]              = openOCDCommandLineEdit->toPlainText();
+        modeJson["openocdOptions"]              = openOCDOptionsLineEdit->toPlainText();
 
         // Symbol File Tab
         modeJson["symbolFile"]                  = symbolFileLineEdit->text();
@@ -894,7 +894,7 @@ bool SeerDebugDialog::loadJsonDoc (const QJsonDocument& jsonDoc, const QString& 
     if (openocdModeJson.isEmpty() == false) {
         // Main Tab
         executableOpenOCDPathLineEdit           ->setText(openocdModeJson["openocdExe"].toString());
-        openOCDCommandLineEdit                  ->setPlainText(openocdModeJson["openocdCommand"].toString());
+        openOCDOptionsLineEdit                  ->setPlainText(openocdModeJson["openocdOptions"].toString());
 
         // Symbol file Tab
         symbolFileLineEdit                      ->setText(openocdModeJson["symbolFile"].toString());
@@ -927,16 +927,16 @@ void SeerDebugDialog::setOpenocdExe(const QString& path)
     executableOpenOCDPathLineEdit->setText(path);
 }
 
-const QString SeerDebugDialog::openocdCommand()
+const QString SeerDebugDialog::openocdOptions()
 {
-    QString tmp = openOCDCommandLineEdit->toPlainText();
+    QString tmp = openOCDOptionsLineEdit->toPlainText();
     tmp.replace("\n", " ");
     return tmp;
 }
 
-void SeerDebugDialog::setOpenocdCommand(const QString& command)
+void SeerDebugDialog::setOpenocdOptions(const QString& options)
 {
-    openOCDCommandLineEdit->setPlainText(command);
+    openOCDOptionsLineEdit->setPlainText(options);
 }
 
 // ::Symbol Files

--- a/src/SeerDebugDialog.h
+++ b/src/SeerDebugDialog.h
@@ -95,25 +95,25 @@ class SeerDebugDialog : public QDialog, protected Ui::SeerDebugDialogForm {
 
         // openocd get and set functions
         // ::Main
-        const QString                       openocdExe                          ();
-        void                                setOpenocdExe                       (const QString& path);
-        const QString                       openocdCommand                      ();
-        void                                setOpenocdCommand                   (const QString& command);
+        const QString           openocdExe                                      ();
+        void                    setOpenocdExe                                   (const QString& path);
+        const QString           openocdOptions                                  ();
+        void                    setOpenocdOptions                               (const QString& options);
         // ::GDB Multiarch
-        const QString                       openocdGdbExe                       ();
-        void                                setOpenocdGdbExe                    (const QString& path);
-        const QString                       openocdGdbPort                      ();
-        void                                setOpenocdGdbPort                   (const QString& port);
-        const QString                       openocdGdbCommand                   ();
-        void                                setOpenocdGdbCommand                (const QString& command);
+        const QString           openocdGdbExe                                   ();
+        void                    setOpenocdGdbExe                                (const QString& path);
+        const QString           openocdGdbPort                                  ();
+        void                    setOpenocdGdbPort                               (const QString& port);
+        const QString           openocdGdbOptions                               ();
+        void                    setOpenocdGdbOptions                            (const QString& options);
         // ::Symbol Files
-        const QString                       symbolFile                          ();
-        void                                setSymbolFile                       (const QString& path);
-        const QString                       workingDirectory                    ();
-        void                                setWorkingDirectory                 (const QString& path);
-        bool                                hasLoadAddress                      ();
-        const QString                       loadAddress                         ();
-        void                                setLoadAddress                      (const QString& address);
+        const QString           symbolFile                                      ();
+        void                    setSymbolFile                                   (const QString& path);
+        const QString           workingDirectory                                ();
+        void                    setWorkingDirectory                             (const QString& path);
+        bool                    hasLoadAddress                                  ();
+        const QString           loadAddress                                     ();
+        void                    setLoadAddress                                  (const QString& address);
 
     protected slots:
         void                    handleExecutableNameToolButton                  ();

--- a/src/SeerDebugDialog.ui
+++ b/src/SeerDebugDialog.ui
@@ -6,71 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>758</width>
+    <width>940</width>
     <height>1086</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Select Executable to Debug</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="executableWorkingDirectoryGroupBox">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="title">
-      <string>Working Directory</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QLineEdit" name="executableWorkingDirectoryLineEdit">
-          <property name="toolTip">
-           <string>The working directory path to tell GDB. Default current directory.</string>
-          </property>
-          <property name="placeholderText">
-           <string>The working directory path to tell GDB. Default current directory.</string>
-          </property>
-          <property name="clearButtonEnabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="executableWorkingDirectoryToolButton">
-          <property name="toolTip">
-           <string>Open a dialog to select a path.</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset resource="resource.qrc">
-            <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
     <widget class="QGroupBox" name="executableNameGroupBox">
      <property name="title">
       <string>Executable Name</string>
@@ -128,7 +72,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item>
     <widget class="QGroupBox" name="executableSymbolNameGroupBox">
      <property name="title">
       <string>Symbol File Name</string>
@@ -186,7 +130,53 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item>
+    <widget class="QGroupBox" name="executableWorkingDirectoryGroupBox">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="title">
+      <string>Working Directory</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLineEdit" name="executableWorkingDirectoryLineEdit">
+          <property name="toolTip">
+           <string>The working directory path to tell GDB. Default current directory.</string>
+          </property>
+          <property name="placeholderText">
+           <string>The working directory path to tell GDB. Default current directory.</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="executableWorkingDirectoryToolButton">
+          <property name="toolTip">
+           <string>Open a dialog to select a path.</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="resource.qrc">
+            <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="launchMethodGroupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -197,8 +187,8 @@
      <property name="title">
       <string>Launch Method</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_4">
-      <item>
+     <layout class="QGridLayout" name="gridLayout_10">
+      <item row="0" column="0">
        <widget class="QTabWidget" name="runModeTabWidget">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -207,7 +197,7 @@
          </sizepolicy>
         </property>
         <property name="currentIndex">
-         <number>0</number>
+         <number>5</number>
         </property>
         <widget class="QWidget" name="runTab">
          <property name="sizePolicy">
@@ -1065,7 +1055,7 @@
           <string>OpenOCD</string>
          </attribute>
          <layout class="QGridLayout" name="gridLayout_12">
-          <item row="0" column="0">
+          <item row="1" column="1">
            <widget class="QTabWidget" name="openOCDTabWidget">
             <property name="currentIndex">
              <number>0</number>
@@ -1076,7 +1066,7 @@
              </attribute>
              <layout class="QVBoxLayout" name="verticalLayout_8">
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_15">
+               <layout class="QHBoxLayout" name="horizontalLayout_14">
                 <item>
                  <widget class="QLabel" name="openOCDMainSettingLabel">
                   <property name="text">
@@ -1098,6 +1088,26 @@
                  </spacer>
                 </item>
                 <item>
+                 <widget class="QToolButton" name="openOCDMainDefaultSettingButton">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Reset to default settings.</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="resource.qrc">
+                    <normaloff>:/seer/resources/RelaxLightIcons/view-refresh.svg</normaloff>:/seer/resources/RelaxLightIcons/view-refresh.svg</iconset>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QToolButton" name="openOCDMainHelpButton">
                   <property name="toolTip">
                    <string>Help for Corefile launch method.</string>
@@ -1114,200 +1124,129 @@
                </layout>
               </item>
               <item>
-               <layout class="QGridLayout" name="gridLayout_10">
+               <layout class="QGridLayout" name="gridLayout_8">
                 <item row="0" column="0">
-                 <widget class="QGroupBox" name="executableNameGroupBox_2">
-                  <property name="enabled">
-                   <bool>true</bool>
+                 <widget class="QLabel" name="executableOpenOCDPathLabel">
+                  <property name="text">
+                   <string>OpenOCD Executable path</string>
                   </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QLineEdit" name="executableOpenOCDPathLineEdit">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                  <property name="maximumSize">
+                  <property name="minimumSize">
                    <size>
-                    <width>16777215</width>
-                    <height>45</height>
+                    <width>24</width>
+                    <height>23</height>
                    </size>
                   </property>
                   <property name="sizeIncrement">
                    <size>
                     <width>20</width>
-                    <height>0</height>
+                    <height>30</height>
                    </size>
                   </property>
-                  <property name="title">
-                   <string notr="true"/>
+                  <property name="baseSize">
+                   <size>
+                    <width>30</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>OpenOCD path.</string>
+                  </property>
+                  <property name="dragEnabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="placeholderText">
+                   <string>OpenOCD path. (eg: /usr/local/bin/openocd)</string>
+                  </property>
+                  <property name="clearButtonEnabled">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="2">
+                 <widget class="QToolButton" name="executableOpenOCDButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>24</width>
+                    <height>23</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>24</width>
+                    <height>23</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Open a dialog to select an executable.</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="resource.qrc">
+                    <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="openOCDOptionsLabel">
+                  <property name="maximumSize">
+                   <size>
+                    <width>150</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>OpenOCD options</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                   </property>
-                  <property name="flat">
-                   <bool>false</bool>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_16">
-                   <item>
-                    <widget class="QLabel" name="executableOpenOCDPathLabel">
-                     <property name="text">
-                      <string>OpenOCD Executable path</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLineEdit" name="executableOpenOCDPathLineEdit">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="sizeIncrement">
-                      <size>
-                       <width>20</width>
-                       <height>30</height>
-                      </size>
-                     </property>
-                     <property name="baseSize">
-                      <size>
-                       <width>30</width>
-                       <height>30</height>
-                      </size>
-                     </property>
-                     <property name="toolTip">
-                      <string>Specify OpenOCD. Eg: /usr/local/bin/openocd</string>
-                     </property>
-                     <property name="dragEnabled">
-                      <bool>false</bool>
-                     </property>
-                     <property name="placeholderText">
-                      <string>Specify OpenOCD. Eg: /usr/local/bin/openocd</string>
-                     </property>
-                     <property name="clearButtonEnabled">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QToolButton" name="executableOpenOCDButton">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="maximumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="toolTip">
-                      <string>Open a dialog to select an executable.</string>
-                     </property>
-                     <property name="text">
-                      <string/>
-                     </property>
-                     <property name="icon">
-                      <iconset resource="resource.qrc">
-                       <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
                  </widget>
                 </item>
-                <item row="0" column="1">
-                 <widget class="QPushButton" name="openOCDMainDefaultSettingButton">
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>25</height>
-                   </size>
+                <item row="1" column="1" colspan="2">
+                 <widget class="QPlainTextEdit" name="openOCDOptionsLineEdit">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
                   </property>
-                  <property name="text">
-                   <string>Default Setting</string>
+                  <property name="toolTip">
+                   <string>OpenOCD adtional options</string>
+                  </property>
+                  <property name="placeholderText">
+                   <string>OpenOCD additional options. (eg: -f &lt;path to&gt;/jlink.cfg -f &lt;path to&gt;/bluepill.cfg)</string>
                   </property>
                  </widget>
                 </item>
                </layout>
               </item>
-              <item>
-               <widget class="QGroupBox" name="executableNameGroupBox_6">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="title">
-                 <string notr="true"/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                </property>
-                <property name="flat">
-                 <bool>false</bool>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_17">
-                 <item>
-                  <widget class="QLabel" name="openOCDCommandLabel">
-                   <property name="maximumSize">
-                    <size>
-                     <width>150</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string>OpenOCD command</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPlainTextEdit" name="openOCDCommandLineEdit">
-                   <property name="toolTip">
-                    <string>OpenOCD commands</string>
-                   </property>
-                   <property name="placeholderText">
-                    <string>OpenOCD additional command. Eg: -f &lt;path to&gt;/jlink.cfg -f &lt;path to&gt;/bluepill.cfg</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>100</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
              </layout>
             </widget>
-            <widget class="QWidget" name="tab">
+            <widget class="QWidget" name="openOCDSymbolFileTab">
              <attribute name="title">
               <string>Symbol FIle</string>
              </attribute>
              <layout class="QVBoxLayout" name="verticalLayout_7">
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_36">
+               <layout class="QHBoxLayout" name="horizontalLayout_13">
                 <item>
                  <widget class="QLabel" name="symbolFileLabel">
                   <property name="text">
@@ -1334,328 +1273,220 @@
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_6">
-                <item>
-                 <widget class="QGroupBox" name="executableNameGroupBox_4">
-                  <property name="enabled">
-                   <bool>true</bool>
+               <layout class="QGridLayout" name="gridLayout">
+                <item row="0" column="0" colspan="2">
+                 <widget class="QLabel" name="executableOpenOCDPathLabel_2">
+                  <property name="text">
+                   <string>Symbol File Name   </string>
                   </property>
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>45</height>
-                   </size>
-                  </property>
-                  <property name="sizeIncrement">
-                   <size>
-                    <width>20</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string notr="true"/>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                  </property>
-                  <property name="flat">
-                   <bool>false</bool>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_13">
-                   <item>
-                    <widget class="QLabel" name="executableOpenOCDPathLabel_2">
-                     <property name="text">
-                      <string>Symbol File Name   </string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLineEdit" name="symbolFileLineEdit">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="sizeIncrement">
-                      <size>
-                       <width>20</width>
-                       <height>30</height>
-                      </size>
-                     </property>
-                     <property name="baseSize">
-                      <size>
-                       <width>30</width>
-                       <height>30</height>
-                      </size>
-                     </property>
-                     <property name="toolTip">
-                      <string>Symbol File</string>
-                     </property>
-                     <property name="dragEnabled">
-                      <bool>false</bool>
-                     </property>
-                     <property name="readOnly">
-                      <bool>false</bool>
-                     </property>
-                     <property name="placeholderText">
-                      <string>Symbol File</string>
-                     </property>
-                     <property name="clearButtonEnabled">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QToolButton" name="openocdSymbolFileButton">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="maximumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="toolTip">
-                      <string>Open a dialog to select an executable.</string>
-                     </property>
-                     <property name="text">
-                      <string/>
-                     </property>
-                     <property name="icon">
-                      <iconset resource="resource.qrc">
-                       <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
                  </widget>
                 </item>
-                <item>
-                 <widget class="QGroupBox" name="executableNameGroupBox_9">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
+                <item row="0" column="2">
+                 <widget class="QLineEdit" name="symbolFileLineEdit">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                  <property name="maximumSize">
+                  <property name="minimumSize">
                    <size>
-                    <width>16777215</width>
-                    <height>45</height>
+                    <width>24</width>
+                    <height>23</height>
                    </size>
                   </property>
                   <property name="sizeIncrement">
                    <size>
                     <width>20</width>
-                    <height>0</height>
+                    <height>30</height>
                    </size>
                   </property>
-                  <property name="title">
-                   <string notr="true"/>
+                  <property name="baseSize">
+                   <size>
+                    <width>30</width>
+                    <height>30</height>
+                   </size>
                   </property>
-                  <property name="alignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                  <property name="toolTip">
+                   <string>Symbol File</string>
                   </property>
-                  <property name="flat">
+                  <property name="dragEnabled">
                    <bool>false</bool>
                   </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_18">
-                   <item>
-                    <widget class="QLabel" name="executableOpenOCDPathLabel_5">
-                     <property name="text">
-                      <string>Working Directory  </string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLineEdit" name="workingDirLineEdit">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="sizeIncrement">
-                      <size>
-                       <width>20</width>
-                       <height>30</height>
-                      </size>
-                     </property>
-                     <property name="baseSize">
-                      <size>
-                       <width>30</width>
-                       <height>30</height>
-                      </size>
-                     </property>
-                     <property name="toolTip">
-                      <string>Working Directory</string>
-                     </property>
-                     <property name="dragEnabled">
-                      <bool>false</bool>
-                     </property>
-                     <property name="placeholderText">
-                      <string>Working Directory</string>
-                     </property>
-                     <property name="clearButtonEnabled">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QToolButton" name="openocdSourceDirButton">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="maximumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="toolTip">
-                      <string>Open a dialog to select an executable.</string>
-                     </property>
-                     <property name="text">
-                      <string/>
-                     </property>
-                     <property name="icon">
-                      <iconset resource="resource.qrc">
-                       <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
+                  <property name="readOnly">
+                   <bool>false</bool>
+                  </property>
+                  <property name="placeholderText">
+                   <string>Symbol File</string>
+                  </property>
+                  <property name="clearButtonEnabled">
+                   <bool>true</bool>
+                  </property>
                  </widget>
                 </item>
-                <item>
-                 <widget class="QGroupBox" name="executableNameGroupBox_8">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
+                <item row="0" column="3">
+                 <widget class="QToolButton" name="openocdSymbolFileButton">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>24</width>
+                    <height>23</height>
+                   </size>
+                  </property>
                   <property name="maximumSize">
                    <size>
-                    <width>16777215</width>
-                    <height>45</height>
+                    <width>24</width>
+                    <height>23</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Open a dialog to select an executable.</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="resource.qrc">
+                    <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0" colspan="2">
+                 <widget class="QLabel" name="executableOpenOCDPathLabel_5">
+                  <property name="text">
+                   <string>Working Directory  </string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="2">
+                 <widget class="QLineEdit" name="workingDirLineEdit">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>24</width>
+                    <height>23</height>
                    </size>
                   </property>
                   <property name="sizeIncrement">
                    <size>
                     <width>20</width>
-                    <height>0</height>
+                    <height>30</height>
                    </size>
                   </property>
-                  <property name="title">
-                   <string notr="true"/>
+                  <property name="baseSize">
+                   <size>
+                    <width>30</width>
+                    <height>30</height>
+                   </size>
                   </property>
-                  <property name="alignment">
-                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                  <property name="toolTip">
+                   <string>Working Directory</string>
                   </property>
-                  <property name="flat">
+                  <property name="dragEnabled">
                    <bool>false</bool>
                   </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_14">
-                   <item>
-                    <widget class="QCheckBox" name="loadAddrCheckBox">
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="executableOpenOCDPathLabel_4">
-                     <property name="text">
-                      <string>Load Address     </string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLineEdit" name="loadAddrLineEdit">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>24</width>
-                       <height>23</height>
-                      </size>
-                     </property>
-                     <property name="sizeIncrement">
-                      <size>
-                       <width>20</width>
-                       <height>30</height>
-                      </size>
-                     </property>
-                     <property name="baseSize">
-                      <size>
-                       <width>30</width>
-                       <height>30</height>
-                      </size>
-                     </property>
-                     <property name="toolTip">
-                      <string>Load Address</string>
-                     </property>
-                     <property name="dragEnabled">
-                      <bool>false</bool>
-                     </property>
-                     <property name="placeholderText">
-                      <string>Load Address</string>
-                     </property>
-                     <property name="clearButtonEnabled">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
+                  <property name="placeholderText">
+                   <string>Working Directory</string>
+                  </property>
+                  <property name="clearButtonEnabled">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="3">
+                 <widget class="QToolButton" name="openocdSourceDirButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>24</width>
+                    <height>23</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>24</width>
+                    <height>23</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Open a dialog to select an executable.</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="resource.qrc">
+                    <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QCheckBox" name="loadAddrCheckBox">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QLabel" name="executableOpenOCDPathLabel_4">
+                  <property name="text">
+                   <string>Load Address     </string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="2">
+                 <widget class="QLineEdit" name="loadAddrLineEdit">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>24</width>
+                    <height>23</height>
+                   </size>
+                  </property>
+                  <property name="sizeIncrement">
+                   <size>
+                    <width>20</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="baseSize">
+                   <size>
+                    <width>30</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Load Address</string>
+                  </property>
+                  <property name="dragEnabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="placeholderText">
+                   <string>Load Address</string>
+                  </property>
+                  <property name="clearButtonEnabled">
+                   <bool>true</bool>
+                  </property>
                  </widget>
                 </item>
                </layout>
@@ -1668,7 +1499,7 @@
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>20</width>
-                  <height>40</height>
+                  <height>126</height>
                  </size>
                 </property>
                </spacer>
@@ -1677,11 +1508,18 @@
             </widget>
            </widget>
           </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Connect to an OpenOCD session.</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </widget>
       </item>
-      <item>
+      <item row="1" column="0">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
          <widget class="QPlainTextEdit" name="preCommandsPlainTextEdit">
@@ -1712,6 +1550,16 @@
        </layout>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -15,6 +15,7 @@
 #include "SeerUtl.h"
 #include "QHContainerWidget.h"
 #include "SeerOpenOCDWidget.h"
+#include "SeerOpenOCDDebugOnInit.h"
 #include <QtGui/QFont>
 #include <QtGui/QGuiApplication>
 #include <QtWidgets/QApplication>
@@ -822,6 +823,10 @@ void SeerGdbWidget::handleText (const QString& text) {
     }else{
         // All other text is ignored by this widget.
     }
+}
+
+void SeerGdbWidget::handleTextDebugOnInit (const QString& text) {
+        qCDebug(LC) << "DebugOnInit: " << text;
 }
 
 void SeerGdbWidget::handleManualCommandExecute (QString command) {
@@ -4225,5 +4230,49 @@ void SeerGdbWidget::handleGdbMultiarchOpenOCDExecutable ()
  * Start of handle Debug On Init
  **********************************************************************************************************************/
 void SeerGdbWidget::handleDebugOnInit () {
+    // Promtp a dialog, tell user to input kernel module that they want to debug
+    SeerOpenOCDDebugOnInit dlg(this);
+    int ret = dlg.exec();
+    if (ret == 0)
+        return;
+    
+    _moduleName                 = dlg.moduleName();
+    _commandToTerm              = dlg.commandToTerm();
+    _kernelModuleSymbolPath     = dlg.kernelModuleSymbolPath();
+    _kernelModuleSourceCodePath = dlg.kernelModuleSourceCodePath();
+    _serialPortPath             = dlg.serialPortPath();
 
+    // Checkpoint
+    if (_kernelModuleSymbolPath == "")
+    {
+        QMessageBox::warning(nullptr, "Seer", QString("Path to kernel module symbol is empty. Abort!"), QMessageBox::Ok);
+        return;
+    }
+    if (_kernelModuleSourceCodePath == "")
+    {
+        QMessageBox::warning(nullptr, "Seer", QString("Path to kernel module source code is empty. Abort!"), QMessageBox::Ok);
+        return;
+    }
+    if ( Seer::isFileExistNotify(_kernelModuleSymbolPath) == false)
+        return;
+    if ( Seer::isDirExistNotify(_kernelModuleSourceCodePath) == false)
+        return;
+    if ( Seer::isFileExistNotify(_serialPortPath) == false)
+        return;
+    if (_moduleName == "" || _commandToTerm == "")
+    {
+        QMessageBox::warning(nullptr, "Seer", QString("Command to terminal is empty. Abort!"), QMessageBox::Ok);
+        return;
+    }
+
+    // Disconnect all signals from _gdbMonitor to this, SeerGdbWidget::handleText
+    QObject::disconnect(_gdbMonitor, &GdbMonitor::astrixTextOutput, this, &SeerGdbWidget::handleText);
+    QObject::disconnect(_gdbMonitor, &GdbMonitor::equalTextOutput,  this, &SeerGdbWidget::handleText);
+    QObject::disconnect(_gdbMonitor, &GdbMonitor::tildeTextOutput,  this, &SeerGdbWidget::handleText);
+
+    // Instead, connect _gdbMonitor signal to SeerGdbWidget::handleTextDebugOnInit
+    QObject::connect(_gdbMonitor, &GdbMonitor::astrixTextOutput, this, &SeerGdbWidget::handleTextDebugOnInit);
+    QObject::connect(_gdbMonitor, &GdbMonitor::equalTextOutput,  this, &SeerGdbWidget::handleTextDebugOnInit);
+    QObject::connect(_gdbMonitor, &GdbMonitor::tildeTextOutput,  this, &SeerGdbWidget::handleTextDebugOnInit);
+    // Checkpoint
 }

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -3991,14 +3991,14 @@ void SeerGdbWidget::setOpenocdExe (const QString& path)
     _openocdExe = path;
 }
 
-const QString& SeerGdbWidget::openocdCommand ()
+const QString& SeerGdbWidget::openocdOptions ()
 {
-    return _openocdCommands;
+    return _openocdOptions;
 }
 
-void SeerGdbWidget::setOpenocdCommand (const QString& command)
+void SeerGdbWidget::setOpenocdOptions (const QString& options)
 {
-    _openocdCommands = command;
+    _openocdOptions = options;
 }
 
 // ::GDB Multiarch
@@ -4097,11 +4097,11 @@ void SeerGdbWidget::handleGdbMultiarchOpenOCDExecutable ()
 
     _openocdWidget->createOpenOCDConsole(commandLogsWidget->logsTabWidgetInstance());
     // Start OpenOCD with the given path and command
-    bool foo = _openocdWidget->startOpenOCD(openocdExe(), openocdCommand());
+    bool foo = _openocdWidget->startOpenOCD(openocdExe(), openocdOptions());
     if (foo == false) {
         QMessageBox::warning(this, "Seer",
                                    QString("Unable to launch the OpenOCD program.\n\n") +
-                                   QString("'%1 %2'").arg(SeerGdbWidget::openocdExe()).arg(SeerGdbWidget::openocdCommand()) + "\n\n" +
+                                   QString("'%1 %2'").arg(SeerGdbWidget::openocdExe()).arg(SeerGdbWidget::openocdOptions()) + "\n\n" +
                                    QString("Please check your OpenOCD configuration."),
                                    QMessageBox::Ok);
         _openocdWidget->terminate();

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -4220,3 +4220,10 @@ void SeerGdbWidget::handleGdbMultiarchOpenOCDExecutable ()
 
     qCDebug(LC) << "Finishing 'gdb-multiarch connect'.";
 }
+
+/***********************************************************************************************************************
+ * Start of handle Debug On Init
+ **********************************************************************************************************************/
+void SeerGdbWidget::handleDebugOnInit () {
+
+}

--- a/src/SeerGdbWidget.h
+++ b/src/SeerGdbWidget.h
@@ -244,6 +244,7 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
 
     public slots:
         void                                handleText                                  (const QString& text);
+        void                                handleTextDebugOnInit                       (const QString& text);
         void                                handleManualCommandExecute                  (QString command);
         void                                handleGdbCommand                            (const QString& command, bool ignoreErrors=false);
         void                                handleGdbCommands                           (const QStringList& commands);
@@ -496,5 +497,12 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
         QString                             _loadAddress;
         QString                             _symbolFile;
         QString                             _sourcePath;
+
+        // Openocd Debug On Init
+        QString                             _moduleName;
+        QString                             _commandToTerm;
+        QString                             _kernelModuleSymbolPath;
+        QString                             _kernelModuleSourceCodePath;
+        QString                             _serialPortPath;
 };
 

--- a/src/SeerGdbWidget.h
+++ b/src/SeerGdbWidget.h
@@ -404,6 +404,7 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
         void                                handleGdbProcessErrored                     (QProcess::ProcessError errorStatus);
 
         void                                handleAboutToQuit                           ();
+        void                                handleDebugOnInit                           ();
 
     signals:
         void                                stoppingPointReached                        ();

--- a/src/SeerGdbWidget.h
+++ b/src/SeerGdbWidget.h
@@ -216,31 +216,31 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
 
         // OpenOCD
         // ::Main
-        const QString&                      openocdExe                          ();
-        void                                setOpenocdExe                       (const QString& path);
-        const QString&                      openocdCommand                      ();
-        void                                setOpenocdCommand                   (const QString& command);
+        const QString&                      openocdExe                                  ();
+        void                                setOpenocdExe                               (const QString& path);
+        const QString&                      openocdOptions                              ();
+        void                                setOpenocdOptions                           (const QString& options);
         // ::GDB Multiarch
-        const QString&                      openocdGdbExe                       ();
-        void                                setOpenocdGdbExe                    (const QString& path);
-        const QString&                      openocdGdbPort                      ();
-        void                                setOpenocdGdbPort                   (const QString& port);
-        const QString&                      openocdTelnetPort                ();
-        void                                setOpenocdTelnetPort             (const QString& port);
-        const QString&                      openocdGdbCommand                   ();
-        void                                setOpenocdGdbCommand                (const QString& command);
+        const QString&                      openocdGdbExe                               ();
+        void                                setOpenocdGdbExe                            (const QString& path);
+        const QString&                      openocdGdbPort                              ();
+        void                                setOpenocdGdbPort                           (const QString& port);
+        const QString&                      openocdTelnetPort                           ();
+        void                                setOpenocdTelnetPort                        (const QString& port);
+        const QString&                      openocdGdbCommand                           ();
+        void                                setOpenocdGdbCommand                        (const QString& command);
 
         // ::Symbol Files
-        void                                setSymbolFile                       (const QString& file);
-        const QString&                      symbolFile                          (void);
-        void                                setLoadAddressEnabled               (bool flag);
-        bool                                loadAddressEnabled                  (void);
-        void                                setLoadAddress                      (const QString& address);
-        const QString&                      loadAddress                         (void);
-        void                                setSourcePath                       (const QString& path);
-        const QString&                      sourcePath                          (void);
+        void                                setSymbolFile                               (const QString& file);
+        const QString&                      symbolFile                                  (void);
+        void                                setLoadAddressEnabled                       (bool flag);
+        bool                                loadAddressEnabled                          (void);
+        void                                setLoadAddress                              (const QString& address);
+        const QString&                      loadAddress                                 (void);
+        void                                setSourcePath                               (const QString& path);
+        const QString&                      sourcePath                                  (void);
 
-        void                                handleGdbMultiarchOpenOCDExecutable ();
+        void                                handleGdbMultiarchOpenOCDExecutable         ();
 
     public slots:
         void                                handleText                                  (const QString& text);
@@ -486,7 +486,7 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
         QString                             _openocdRunningState;
         // OpenOCD
         QString                             _openocdExe;
-        QString                             _openocdCommands;
+        QString                             _openocdOptions;
         // GDB Multiarch
         QString                             _openocdGdbExe;
         QString                             _openocdGdbPort;

--- a/src/SeerMainWindow.cpp
+++ b/src/SeerMainWindow.cpp
@@ -667,9 +667,10 @@ void SeerMainWindow::handleFileDebug (bool loadDefaultProject) {
     dlg.setCoreFilename(executableCoreFilename());
     dlg.setPreGdbCommands(executablePreGdbCommands());
     dlg.setPostGdbCommands(executablePostGdbCommands());
+
     // OpenOCD
     dlg.setOpenocdExe(openocdExe());
-    dlg.setOpenocdCommand(openocdCommand());
+    dlg.setOpenocdOptions(openocdOptions());
     dlg.setSymbolFile(symbolFile());
 
     // If there's a project, use it.
@@ -719,7 +720,7 @@ void SeerMainWindow::handleFileDebug (bool loadDefaultProject) {
 
     // read openocd variables
     setOpenocdExe(dlg.openocdExe());
-    setOpenocdCommand(dlg.openocdCommand());
+    setOpenocdOptions(dlg.openocdOptions());
     setSymbolFile(dlg.symbolFile());
 
     launchExecutable(launchMode, breakMode);
@@ -2272,12 +2273,12 @@ void SeerMainWindow::setOpenocdExe (const QString& path) {
     gdbWidget->setOpenocdExe(path);
 }
 
-const QString& SeerMainWindow::openocdCommand() {
-    return gdbWidget->openocdCommand();
+const QString& SeerMainWindow::openocdOptions() {
+    return gdbWidget->openocdOptions();
 }
 
-void SeerMainWindow::setOpenocdCommand (const QString& command){
-    gdbWidget->setOpenocdCommand(command);
+void SeerMainWindow::setOpenocdOptions (const QString& options){
+    gdbWidget->setOpenocdOptions(options);
 }
 
 // ::GDB Multiarch

--- a/src/SeerMainWindow.cpp
+++ b/src/SeerMainWindow.cpp
@@ -111,6 +111,9 @@ SeerMainWindow::SeerMainWindow(QWidget* parent) : QMainWindow(parent) {
     actionGdbStepi->setVisible(false);
     actionGdbFinish->setVisible(true);
 
+    // OpenOCD disable Debug On Init by default
+    actionDebugOnInit->setVisible(false);
+
     // Set up Interrupt menu.
     QMenu* menuInterrupt = new QMenu(this);
     _interruptAction = menuInterrupt->addAction("Interrupt");
@@ -188,6 +191,7 @@ SeerMainWindow::SeerMainWindow(QWidget* parent) : QMainWindow(parent) {
     QObject::connect(actionControlRecordReverse,        &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbRecordReverse);
     QObject::connect(actionControlRecordStop,           &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbRecordStop);
     QObject::connect(actionControlInterrupt,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterrupt);
+    QObject::connect(actionDebugOnInit,                 &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleDebugOnInit);
 
     QObject::connect(actionSettingsConfiguration,       &QAction::triggered,                            this,                           &SeerMainWindow::handleSettingsConfiguration);
     QObject::connect(actionSettingsSaveConfiguration,   &QAction::triggered,                            this,                           &SeerMainWindow::handleSettingsSaveConfiguration);
@@ -502,6 +506,7 @@ void SeerMainWindow::launchExecutable (const QString& launchMode, const QString&
     actionControlRestart->setVisible(true);
     actionControlTerminate->setVisible(true);
     actionControlInterrupt->setVisible(true);
+    actionDebugOnInit->setVisible(false);
 
     if (launchMode == "run") {
 
@@ -545,6 +550,7 @@ void SeerMainWindow::launchExecutable (const QString& launchMode, const QString&
         actionGdbStepi->setVisible(false);
         actionControlNexti->setVisible(false);
         actionControlStepi->setVisible(false);
+        actionDebugOnInit->setVisible(true);
         // launch gdb-multiarch and openocd
         gdbWidget->handleGdbMultiarchOpenOCDExecutable();
 
@@ -1087,6 +1093,7 @@ void SeerMainWindow::handleRestartExecutable () {
         actionGdbStepi->setVisible(false);
         actionControlNexti->setVisible(false);
         actionControlStepi->setVisible(false);
+        actionDebugOnInit->setVisible(true);
         gdbWidget->handleGdbMultiarchOpenOCDExecutable();
 
     }
@@ -1206,6 +1213,7 @@ void SeerMainWindow::handleGdbStateChanged () {
         actionGdbTerminate->setVisible(false);
         actionControlRestart->setVisible(true);
         actionControlTerminate->setVisible(true);
+        actionDebugOnInit->setVisible(false);
 
         // Get the hotkey for the Restart button.
         QString hotkey = "";

--- a/src/SeerMainWindow.h
+++ b/src/SeerMainWindow.h
@@ -83,8 +83,8 @@ class SeerMainWindow : public QMainWindow, protected Ui::SeerMainWindowForm {
         // ::Main
         const QString&              openocdExe                              ();
         void                        setOpenocdExe                           (const QString& path);
-        const QString&              openocdCommand                          ();
-        void                        setOpenocdCommand                       (const QString& command);
+        const QString&              openocdOptions                          ();
+        void                        setOpenocdOptions                       (const QString& options);
         // ::GDB Multiarch
         const QString&              openocdGdbExe                           ();
         void                        setOpenocdGdbExe                        (const QString& path);

--- a/src/SeerMainWindow.ui
+++ b/src/SeerMainWindow.ui
@@ -203,6 +203,8 @@
    <addaction name="actionInterruptProcess"/>
    <addaction name="separator"/>
    <addaction name="actionVisualizers"/>
+   <addaction name="separator"/>
+   <addaction name="actionDebugOnInit"/>
   </widget>
   <action name="actionFileQuit">
    <property name="icon">
@@ -831,6 +833,15 @@
    </property>
    <property name="text">
     <string>GDB Monitor</string>
+   </property>
+  </action>
+  <action name="actionDebugOnInit">
+   <property name="icon">
+    <iconset resource="resource.qrc">
+     <normaloff>:/seer/resources/icons-icons/debug.png</normaloff>:/seer/resources/icons-icons/debug.png</iconset>
+   </property>
+   <property name="text">
+    <string>Debug On Init</string>
    </property>
   </action>
  </widget>

--- a/src/SeerOpenOCDDebugOnInit.cpp
+++ b/src/SeerOpenOCDDebugOnInit.cpp
@@ -1,0 +1,132 @@
+#include "SeerOpenOCDDebugOnInit.h"
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QToolButton>
+#include <QLineEdit>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QSerialPortInfo>
+
+SeerOpenOCDDebugOnInit::SeerOpenOCDDebugOnInit (QWidget* parent) : QDialog(parent) {
+
+    // Set up the UI.
+    setupUi(this);
+
+    // Connect signal and slots
+    QObject::connect(kernelModuleSymbolButton,          &QToolButton::clicked,          this,           &SeerOpenOCDDebugOnInit::handleKernelModuleSymbolButton);
+    QObject::connect(kernelModuleSourceCodeButton,      &QToolButton::clicked,          this,           &SeerOpenOCDDebugOnInit::handleKernelModuleSourceCodeButton);
+    QObject::connect(moduleNameLineEdit,                &QLineEdit::textChanged,        [&](const QString &text){   commandLineEdit->setText("insmod " + text + ".ko");   });
+    QObject::connect(buttonBox,                         &QDialogButtonBox::accepted,    this,           &SeerOpenOCDDebugOnInit::onAccepted);
+    QObject::connect(serialComboBox,                    &QComboBox::currentTextChanged, this,           &SeerOpenOCDDebugOnInit::handleComboBoxTextChanged);
+    
+    _moduleName                     = "";
+    _commandToTerm                  = "insmod ";;
+    _kernelModuleSymbolPath         = "";
+    _kernelModuleSourceCodePath     = "";
+    _serialPortPath                 = "";
+
+    const auto ports = QSerialPortInfo::availablePorts();
+
+    for (const QSerialPortInfo &port : ports)
+    {
+        if (port.portName().contains("ttyUSB"))
+        {
+            serialComboBox->addItem(QString(port.systemLocation()));
+        }
+    }
+
+    for (const QSerialPortInfo &port : ports)
+    {
+        if (!port.portName().contains("ttyUSB"))
+            serialComboBox->addItem(QString(port.systemLocation()));
+    }
+    
+}
+
+SeerOpenOCDDebugOnInit::~SeerOpenOCDDebugOnInit () {
+}
+
+/***********************************************************************************************************************
+ * Getter and setter
+ **********************************************************************************************************************/
+void SeerOpenOCDDebugOnInit::setModuleName (const QString& name)
+{
+    _moduleName = name;
+}
+
+const QString SeerOpenOCDDebugOnInit::moduleName ()
+{
+    return _moduleName;
+}
+
+void SeerOpenOCDDebugOnInit::setCommandToTerm (const QString& command)
+{
+    _commandToTerm = command;
+}
+
+const QString SeerOpenOCDDebugOnInit::commandToTerm ()
+{
+    return _commandToTerm;
+}
+
+void SeerOpenOCDDebugOnInit::setkernelModuleSymbolPath (const QString& path)
+{
+    _kernelModuleSymbolPath = path;
+}
+
+const QString SeerOpenOCDDebugOnInit::kernelModuleSymbolPath ()
+{
+    return _kernelModuleSymbolPath;
+}
+
+void SeerOpenOCDDebugOnInit::setKernelModuleSourceCodePath (const QString& path)
+{
+    _kernelModuleSourceCodePath = path;
+}
+
+const QString SeerOpenOCDDebugOnInit::kernelModuleSourceCodePath ()
+{
+    return _kernelModuleSourceCodePath;
+}
+
+void SeerOpenOCDDebugOnInit::setSerialPortPath (const QString& path)
+{
+    _serialPortPath = path;
+}
+
+const QString SeerOpenOCDDebugOnInit::serialPortPath()
+{
+    return _serialPortPath;
+}
+/***********************************************************************************************************************
+ * Slot handling open file / folder
+ **********************************************************************************************************************/
+void SeerOpenOCDDebugOnInit::handleKernelModuleSymbolButton () {
+    QString name = QFileDialog::getOpenFileName(this, "Selec Kernel Module Symbol.", kernelModuleSymbolPath(), "", nullptr, QFileDialog::DontUseNativeDialog);
+
+    if (name != "") {
+        setkernelModuleSymbolPath(name);
+        kernelModuleSymbolLineEdit->setText(kernelModuleSymbolPath());
+    }
+}
+
+void SeerOpenOCDDebugOnInit::handleKernelModuleSourceCodeButton () {
+    QString name = QFileDialog::getExistingDirectory(this, "Select kernel source code directory.", kernelModuleSourceCodePath(), QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
+
+    if (name != "") {
+        setKernelModuleSourceCodePath(name);
+        kernelModuleSourceCodeLineEdit->setText(kernelModuleSourceCodePath());
+    }
+}
+
+void SeerOpenOCDDebugOnInit::handleComboBoxTextChanged()
+{
+    setSerialPortPath(serialComboBox->currentText());
+}
+
+void SeerOpenOCDDebugOnInit::onAccepted()
+{
+    setModuleName(moduleNameLineEdit->text());
+    setCommandToTerm(commandLineEdit->text());
+    setkernelModuleSymbolPath(kernelModuleSymbolLineEdit->text());
+    setKernelModuleSourceCodePath(kernelModuleSourceCodeLineEdit->text());
+}

--- a/src/SeerOpenOCDDebugOnInit.h
+++ b/src/SeerOpenOCDDebugOnInit.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QButtonGroup>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+
+#include "ui_SeerOpenOCDDebugOnInit.h"
+
+class SeerOpenOCDDebugOnInit : public QDialog, protected Ui::SeerOpenOCDDebugOnInit {
+
+    Q_OBJECT
+
+    public:
+        explicit SeerOpenOCDDebugOnInit (QWidget* parent = 0);
+       ~SeerOpenOCDDebugOnInit ();
+        void                    setModuleName                       (const QString& name);
+        const QString           moduleName                          ();
+        void                    setCommandToTerm                    (const QString& command);
+        const QString           commandToTerm                       ();
+        void                    setkernelModuleSymbolPath           (const QString& path);
+        const QString           kernelModuleSymbolPath              ();
+        void                    setKernelModuleSourceCodePath       (const QString& path);
+        const QString           kernelModuleSourceCodePath          ();
+        void                    setSerialPortPath                   (const QString& path);
+        const QString           serialPortPath                      ();
+
+    private slots:
+        void            handleKernelModuleSymbolButton              ();
+        void            handleKernelModuleSourceCodeButton          ();
+        void            onAccepted                                  ();
+        void            handleComboBoxTextChanged                   ();
+
+    private:
+        QString         _moduleName;
+        QString         _commandToTerm;
+        QString         _kernelModuleSymbolPath;
+        QString         _kernelModuleSourceCodePath;
+        QString         _serialPortPath;
+
+
+};
+

--- a/src/SeerOpenOCDDebugOnInit.ui
+++ b/src/SeerOpenOCDDebugOnInit.ui
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SeerOpenOCDDebugOnInit</class>
+ <widget class="QDialog" name="SeerOpenOCDDebugOnInit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>603</width>
+    <height>254</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Ignored">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>254</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>254</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Module name (without .ko)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="moduleNameLineEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Send command to TERM window</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="commandLineEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_5">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Serial Port</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="serialComboBox"/>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout_5">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
+     <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Path to kernel module symbol file (.ko)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLineEdit" name="kernelModuleSymbolLineEdit"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="kernelModuleSymbolButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>24</width>
+             <height>23</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>24</width>
+             <height>23</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="resource.qrc">
+             <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Path to kernel module source code</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLineEdit" name="kernelModuleSourceCodeLineEdit"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="kernelModuleSourceCodeButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>24</width>
+             <height>23</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>24</width>
+             <height>23</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="resource.qrc">
+             <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="resource.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SeerOpenOCDDebugOnInit</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SeerOpenOCDDebugOnInit</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
On previous MR, I deployed Goto Definition in MR https://github.com/epasveer/seer/pull/437
This works with MCUs and desktop applications but won't work with MPU (typically running Linux kernel)
Eg: if you send cmds like: -symbol-info-functions, -symbol-info-types to gdbwidget, it gdb won't response. I don't know why, tbh
Also, in previous MR, I introduced the 2nd gdb process to handle live watch: https://github.com/epasveer/seer/pull/469

-> So the work around is:
1. Whenever users use Alt + Click to identifier, SeerEditorManagerWidget::gotoDefinitionForwarder will emit some signal
2. Direct this signal to the 2nd gdb process, letting it handles commands: -symbol-info-functions, -symbol-info-types. Because 1st and 2nd gdb processes are loaded the same symbol files, with the same commands, so a specfic function, type or variable on 1 gdb process will match exactly like the one in the other gdb process
3. After fetching the output of -symbol-info-functions, -symbol-info-types, the 2nd gdb process will send it back to SeerEditorManagerWidget to handle GotoDefinition

Please have a look
I will update test cas for Raspberry Pi when your pcb arrives