### PR TITLE
Seer handles dark/light color theme changes. Especially for Icons.

### DIFF
--- a/src/SeerAboutDialog.cpp
+++ b/src/SeerAboutDialog.cpp
@@ -6,6 +6,8 @@
 #include "SeerUtl.h"
 #include <QtGui/QColor>
 #include <QtGui/QPalette>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtCore/QFile>
 #include <QtCore/QString>
 #include <QtCore/QDebug>
@@ -14,6 +16,9 @@ SeerAboutDialog::SeerAboutDialog (QWidget* parent) : QDialog(parent) {
 
     // Set up the UI.
     setupUi(this);
+
+    // Handle when theme is changed. Change the color of all icons.
+    QObject::connect(QGuiApplication::styleHints(),  &QStyleHints::colorSchemeChanged,         this, &SeerAboutDialog::handleThemeChanged);
 
     // Get the About text from the resource.
     QFile file(":/seer/resources/ABOUT.md");
@@ -34,14 +39,19 @@ SeerAboutDialog::SeerAboutDialog (QWidget* parent) : QDialog(parent) {
     textBrowser->setMarkdown(text);
     textBrowser->moveCursor (QTextCursor::Start);
 
-    // Set the TextBrowser's background to the same as the window's.
-    QColor windowColor = palette().color(QWidget::backgroundRole());
-
-    QPalette p = textBrowser->palette();
-    p.setColor(QPalette::Base, windowColor);
-    textBrowser->setPalette(p);
+    // Set the label's icon.
+    handleThemeChanged();
 }
 
 SeerAboutDialog::~SeerAboutDialog () {
+}
+
+void SeerAboutDialog::handleThemeChanged () {
+
+    // Get the colorized icon.
+    QIcon icon = Seer::colorizeIcon(QIcon(":/seer/resources/icons/hicolor/256x256/seergdb.png"), QSize(256,256));
+
+    // Set the label's pixmap
+    label->setPixmap(icon.pixmap(QSize(256,256)));
 }
 

--- a/src/SeerAboutDialog.h
+++ b/src/SeerAboutDialog.h
@@ -17,7 +17,9 @@ class SeerAboutDialog : public QDialog, protected Ui::SeerAboutDialogForm {
         explicit SeerAboutDialog (QWidget* parent = 0);
        ~SeerAboutDialog ();
 
-    public slots:
+    public  slots:
+    private slots:
+        void        handleThemeChanged ();
 
     private:
 };

--- a/src/SeerArrayVisualizerWidget.cpp
+++ b/src/SeerArrayVisualizerWidget.cpp
@@ -13,7 +13,8 @@
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QToolTip>
 #include <QtGui/QIntValidator>
-#include <QtGui/QIcon>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtPrintSupport/QPrinter>
 #include <QtPrintSupport/QPrintDialog>
 #include <QtCore/QRegularExpression>
@@ -43,7 +44,6 @@ SeerArrayVisualizerWidget::SeerArrayVisualizerWidget (QWidget* parent) : QWidget
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Array Visualizer");
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -106,6 +106,11 @@ SeerArrayVisualizerWidget::SeerArrayVisualizerWidget (QWidget* parent) : QWidget
     QObject::connect(labelsCheckBox,                &QCheckBox::clicked,                                       this,            &SeerArrayVisualizerWidget::handleLabelsCheckBox);
     QObject::connect(lineTypeButtonGroup,           QOverload<int>::of(&QButtonGroup::idClicked),              this,            &SeerArrayVisualizerWidget::handleLineTypeButtonGroup);
     QObject::connect(printPushButton,               &QPushButton::clicked,                                     arrayChartView,  &QZoomChartView::printView);
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,                          this,            &SeerArrayVisualizerWidget::handleThemeChanged);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
+    Seer::colorizeChartViewItem(arrayChartView);
 
     // Restore window settings.
     readSettings();
@@ -1075,6 +1080,15 @@ void SeerArrayVisualizerWidget::handleLabelsCheckBox () {
 void SeerArrayVisualizerWidget::handleLineTypeButtonGroup () {
 
     handleDataChanged();
+}
+
+void SeerArrayVisualizerWidget::handleThemeChanged () {
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
+
+    // And the ChartView.
+    Seer::colorizeChartViewItem(arrayChartView);
 }
 
 void SeerArrayVisualizerWidget::createASeries() {

--- a/src/SeerArrayVisualizerWidget.h
+++ b/src/SeerArrayVisualizerWidget.h
@@ -68,6 +68,7 @@ class SeerArrayVisualizerWidget : public QWidget, protected Ui::SeerArrayVisuali
         void                handlePointsCheckBox                ();
         void                handleLabelsCheckBox                ();
         void                handleLineTypeButtonGroup           ();
+        void                handleThemeChanged                  ();
 
     protected:
         void                writeSettings                       ();

--- a/src/SeerConfigDialog.cpp
+++ b/src/SeerConfigDialog.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "SeerConfigDialog.h"
+#include "SeerUtl.h"
 #include <QtWidgets/QListWidget>
 #include <QtWidgets/QListWidgetItem>
 #include <QtWidgets/QStackedWidget>
@@ -107,6 +108,16 @@ SeerConfigDialog::SeerConfigDialog(QWidget* parent) : QDialog(parent) {
     // Connect things.
     connect(contentsListWidget, &QListWidget::currentItemChanged,   this, &SeerConfigDialog::handleChangePage);
     connect(buttonBox,          &QDialogButtonBox::clicked,         this, &SeerConfigDialog::handleButtonClicked);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
+    Seer::colorizeListWidgetItemIcon(configSeerButton,     QSize(128,128));
+    Seer::colorizeListWidgetItemIcon(configGdbButton,      QSize(128,128));
+    Seer::colorizeListWidgetItemIcon(configEditorButton,   QSize(128,128));
+    Seer::colorizeListWidgetItemIcon(configSourceButton,   QSize(128,128));
+    Seer::colorizeListWidgetItemIcon(configAssemblyButton, QSize(128,128));
+    Seer::colorizeListWidgetItemIcon(configKeysButton,     QSize(128,128));
+    // Seer::colorizeListWidgetItemIcon(configRRButton,       QSize(128,128)); // Don't change. It's a multi-colored icon.
 
     // Set to first page.
     contentsListWidget->setCurrentRow(0);

--- a/src/SeerConsoleWidget.cpp
+++ b/src/SeerConsoleWidget.cpp
@@ -36,7 +36,6 @@ SeerConsoleWidget::SeerConsoleWidget (QWidget* parent) : QWidget(parent) {
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Console");
 
     textEdit->setReadOnly(true);

--- a/src/SeerDebugDialog.cpp
+++ b/src/SeerDebugDialog.cpp
@@ -75,6 +75,8 @@ SeerDebugDialog::SeerDebugDialog (QWidget* parent) : QDialog(parent) {
     QObject::connect(buttonBox,                            &QDialogButtonBox::accepted,         this, &SeerDebugDialog::handleLaunchButtonClicked);
     QObject::connect(buttonBox,                            &QDialogButtonBox::clicked,          this, &SeerDebugDialog::handleResetButtonClicked);
 
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     // Set initial run mode.
     handleRunModeChanged(0);

--- a/src/SeerEditorManagerWidget.cpp
+++ b/src/SeerEditorManagerWidget.cpp
@@ -12,6 +12,8 @@
 #include <QtWidgets/QToolButton>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QMessageBox>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtCore/QString>
 #include <QtCore/QTextStream>
 #include <QtCore/QFile>
@@ -25,10 +27,10 @@
 SeerEditorManagerWidget::SeerEditorManagerWidget (QWidget* parent) : QWidget(parent) {
 
     // Initialize private data
-    _editorFont                     = QFont("monospace", 10);                      // Default font.
+    _editorFont                     = QFont("monospace", 10);                // Default font.
     _editorHighlighterSettings      = SeerHighlighterSettings::populate(""); // Default syntax highlighting.
     _editorHighlighterEnabled       = true;
-    _editorKeySettings              = SeerKeySettings::populate();                 // Default key settings.
+    _editorKeySettings              = SeerKeySettings::populate();           // Default key settings.
     _editorTabSize                  = 4;
     _editorExternalEditorCommand    = "";
     _editorAutoSourceReload         = false;
@@ -81,12 +83,13 @@ SeerEditorManagerWidget::SeerEditorManagerWidget (QWidget* parent) : QWidget(par
     createEditorWidgetTab("", "");
 
     // Connect things.
-    QObject::connect(tabWidget,             &QTabWidget::tabCloseRequested,    this, &SeerEditorManagerWidget::handleTabCloseRequested);
-    QObject::connect(tabWidget,             &QTabWidget::currentChanged,       this, &SeerEditorManagerWidget::handleTabCurrentChanged);
-    QObject::connect(fileOpenToolButton,    &QToolButton::clicked,             this, &SeerEditorManagerWidget::handleFileOpenToolButtonClicked);
-    QObject::connect(fileCloseToolButton,   &QToolButton::clicked,             this, &SeerEditorManagerWidget::handleFileCloseToolButtonClicked);
-    QObject::connect(textSearchToolButton,  &QToolButton::clicked,             this, &SeerEditorManagerWidget::handleTextSearchToolButtonClicked);
-    QObject::connect(helpToolButton,        &QToolButton::clicked,             this, &SeerEditorManagerWidget::handleHelpToolButtonClicked);
+    QObject::connect(tabWidget,                     &QTabWidget::tabCloseRequested,    this, &SeerEditorManagerWidget::handleTabCloseRequested);
+    QObject::connect(tabWidget,                     &QTabWidget::currentChanged,       this, &SeerEditorManagerWidget::handleTabCurrentChanged);
+    QObject::connect(fileOpenToolButton,            &QToolButton::clicked,             this, &SeerEditorManagerWidget::handleFileOpenToolButtonClicked);
+    QObject::connect(fileCloseToolButton,           &QToolButton::clicked,             this, &SeerEditorManagerWidget::handleFileCloseToolButtonClicked);
+    QObject::connect(textSearchToolButton,          &QToolButton::clicked,             this, &SeerEditorManagerWidget::handleTextSearchToolButtonClicked);
+    QObject::connect(helpToolButton,                &QToolButton::clicked,             this, &SeerEditorManagerWidget::handleHelpToolButtonClicked);
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,  this, &SeerEditorManagerWidget::handleThemeChanged);
 
     // Add combination shortcut for re-open closed file (Ctrl + Shift + T)
     QShortcut *shortcut = new QShortcut(QKeySequence("Ctrl+Shift+T"), this);
@@ -1662,6 +1665,33 @@ void SeerEditorManagerWidget::handleOpenForwardBackward(const SeerEditorWidgetSo
         editorWidget->sourceArea()->setTextCursor(cursor);
     }
 }
+
+void SeerEditorManagerWidget::handleThemeChanged () {
+
+    //
+    // Normally, we would colorize all the icons in this widget and its
+    // childred, however, this is already handled in SeerMainWindow.
+    //
+    // Instead, we change the editor's color scheme here.
+    //
+
+    // Get the current color scheme
+    Qt::ColorScheme colorScheme = QGuiApplication::styleHints()->colorScheme();
+
+    // Switch to the right scheme.
+    SeerHighlighterSettings settings;
+
+    if (colorScheme == Qt::ColorScheme::Dark) {
+        settings = SeerHighlighterSettings::populate_dark();
+    }else{
+        settings = SeerHighlighterSettings::populate_light();
+    }
+
+    // Set the new color scheme for the editor manager.
+    // This updates all existing editors.
+    setEditorHighlighterSettings(settings);
+}
+
 // Handle mouse press events for navigation
 void SeerEditorManagerWidget::mousePressEvent(QMouseEvent *event)
 {

--- a/src/SeerEditorManagerWidget.h
+++ b/src/SeerEditorManagerWidget.h
@@ -107,6 +107,7 @@ class SeerEditorManagerWidget : public QWidget, protected Ui::SeerEditorManagerW
         void                                            handleSessionTerminated             ();
         void                                            handleGdbStateChanged               ();
         void                                            handleAddToMouseNavigation          (const SeerEditorWidgetSourceArea::SeerCurrentFile& currentFile);
+        void                                            handleThemeChanged                  ();
 
     protected:
         void                                            mousePressEvent                     (QMouseEvent *event) override;

--- a/src/SeerGdbMonitorWidget.cpp
+++ b/src/SeerGdbMonitorWidget.cpp
@@ -11,6 +11,8 @@
 #include <QtPrintSupport/QPrinter>
 #include <QtPrintSupport/QPrintDialog>
 #include <QtGui/QFont>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtCore/QTextStream>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QSettings>
@@ -25,7 +27,6 @@ SeerGdbMonitorWidget::SeerGdbMonitorWidget (QWidget* parent) : QWidget(parent) {
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer - GDB Monitor");
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -59,6 +60,10 @@ SeerGdbMonitorWidget::SeerGdbMonitorWidget (QWidget* parent) : QWidget(parent) {
     QObject::connect(printToolButton,               &QToolButton::clicked,                                     this,            &SeerGdbMonitorWidget::handlePrintButton);
     QObject::connect(helpToolButton,                &QToolButton::clicked,                                     this,            &SeerGdbMonitorWidget::handleHelpButton);
     QObject::connect(macroButtonGroup,              &QButtonGroup::buttonClicked,                              this,            &SeerGdbMonitorWidget::handleMacroToolButtonClicked);
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,                          this,            &SeerGdbMonitorWidget::handleThemeChanged);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     // Restore window settings.
     readSettings();
@@ -182,6 +187,12 @@ void SeerGdbMonitorWidget::handleMacroToolButtonClicked (QAbstractButton* button
 
         emit executeGdbMonitorCommand(_monitorId, command);
     }
+}
+
+void SeerGdbMonitorWidget::handleThemeChanged () {
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 }
 
 void SeerGdbMonitorWidget::writeSettings() {

--- a/src/SeerGdbMonitorWidget.h
+++ b/src/SeerGdbMonitorWidget.h
@@ -28,6 +28,7 @@ class SeerGdbMonitorWidget : public QWidget, protected Ui::SeerGdbMonitorWidgetF
         void                handlePrintButton                   ();
         void                handleHelpButton                    ();
         void                handleMacroToolButtonClicked        (QAbstractButton* button);
+        void                handleThemeChanged                  ();
 
     protected:
         void                writeSettings                       ();

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -474,7 +474,6 @@ const QString& SeerGdbWidget::executableBreakpointSourceName () const {
 }
 
 void SeerGdbWidget::setExecutableBreakpointFirstInstruction (bool flag) {
-    qDebug() << flag;
     _executableBreakpointFirstInstruction = flag;
 }
 
@@ -2159,8 +2158,6 @@ void SeerGdbWidget::handleGdbBreakpointsInsert (QString breakpoints) {
 }
 
 void SeerGdbWidget::handleGdbBreakpointInsert (QString breakpoint) {
-
-    qDebug() << breakpoint;
 
     if (executableLaunchMode() == "") {
         return;

--- a/src/SeerHelpPageDialog.cpp
+++ b/src/SeerHelpPageDialog.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "SeerHelpPageDialog.h"
+#include "SeerUtl.h"
 #include <QtPrintSupport/QPrinter>
 #include <QtPrintSupport/QPrintDialog>
 #include <QtWidgets/QToolButton>
@@ -17,7 +18,6 @@ SeerHelpPageDialog::SeerHelpPageDialog(QDialog* parent) : QDialog(parent) {
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Help");
 
     textBrowser->setOpenExternalLinks(true);
@@ -25,6 +25,9 @@ SeerHelpPageDialog::SeerHelpPageDialog(QDialog* parent) : QDialog(parent) {
     // Connect things.
     QObject::connect(printToolButton,  &QToolButton::clicked,          this,  &SeerHelpPageDialog::handlePrintToolButton);
     QObject::connect(okPushButton,     &QPushButton::clicked,          this,  &SeerHelpPageDialog::handleOkPushButton);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     // Restore window settings.
     readSettings();

--- a/src/SeerHighlighterSettings.cpp
+++ b/src/SeerHighlighterSettings.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "SeerHighlighterSettings.h"
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 
 SeerHighlighterSettings::SeerHighlighterSettings () {
 }
@@ -117,14 +119,26 @@ QStringList SeerHighlighterSettings::themeNames() {
 
     QStringList names;
 
-    names << "light" << "dark";
+    names << "auto" << "light" << "dark";
 
     return names;
 }
 
 SeerHighlighterSettings SeerHighlighterSettings::populate (const QString& themeName) {
 
-    if (themeName == "light") {
+
+    if (themeName == "auto") {
+
+        // Get the current color scheme
+        Qt::ColorScheme colorScheme = QGuiApplication::styleHints()->colorScheme();
+
+        if (colorScheme == Qt::ColorScheme::Dark) {
+            return SeerHighlighterSettings::populate_dark();
+        }else{
+            return SeerHighlighterSettings::populate_light();
+        }
+
+    }else if (themeName == "light") {
         return SeerHighlighterSettings::populate_light();
     }else if (themeName == "dark") {
         return SeerHighlighterSettings::populate_dark();

--- a/src/SeerImageVisualizerWidget.cpp
+++ b/src/SeerImageVisualizerWidget.cpp
@@ -8,7 +8,8 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QFileDialog>
 #include <QtGui/QIntValidator>
-#include <QtGui/QIcon>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtPrintSupport/QPrinter>
 #include <QtPrintSupport/QPrintDialog>
 #include <QtCore/QSettings>
@@ -31,7 +32,6 @@ SeerImageVisualizerWidget::SeerImageVisualizerWidget (QWidget* parent) : QWidget
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Image Visualizer");
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -47,6 +47,10 @@ SeerImageVisualizerWidget::SeerImageVisualizerWidget (QWidget* parent) : QWidget
     QObject::connect(formatComboBox,                QOverload<int>::of(&QComboBox::currentIndexChanged),       this,  &SeerImageVisualizerWidget::handleFormatComboBox);
     QObject::connect(printToolButton,               &QToolButton::clicked,                                     this,  &SeerImageVisualizerWidget::handlePrintButton);
     QObject::connect(saveToolButton,                &QToolButton::clicked,                                     this,  &SeerImageVisualizerWidget::handleSaveButton);
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,                          this,  &SeerImageVisualizerWidget::handleThemeChanged);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     // Restore window settings.
     readSettings();
@@ -408,6 +412,12 @@ void SeerImageVisualizerWidget::handleCreateImage (const QByteArray& array) {
     QImage image = QImage((const uchar*)array.data(), _width, _height, _format);
 
     imageViewer->setImage(image);
+}
+
+void SeerImageVisualizerWidget::handleThemeChanged () {
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 }
 
 void SeerImageVisualizerWidget::writeSettings() {

--- a/src/SeerImageVisualizerWidget.h
+++ b/src/SeerImageVisualizerWidget.h
@@ -41,6 +41,7 @@ class SeerImageVisualizerWidget : public QWidget, protected Ui::SeerImageVisuali
         void                handlePrintButton                   ();
         void                handleSaveButton                    ();
         void                handleCreateImage                   (const QByteArray& array);
+        void                handleThemeChanged                  ();
 
     protected:
         void                writeSettings                       ();

--- a/src/SeerMacroEditorDialog.ui
+++ b/src/SeerMacroEditorDialog.ui
@@ -13,10 +13,6 @@
   <property name="windowTitle">
    <string>Seer - Macro Editor</string>
   </property>
-  <property name="windowIcon">
-   <iconset resource="resource.qrc">
-    <normaloff>:/seer/resources/icons/hicolor/32x32/seergdb.png</normaloff>:/seer/resources/icons/hicolor/32x32/seergdb.png</iconset>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QPlainTextEdit" name="textEditor">

--- a/src/SeerMainWindow.cpp
+++ b/src/SeerMainWindow.cpp
@@ -16,9 +16,11 @@
 #include <QtWidgets/QToolTip>
 #include <QtGui/QKeySequence>
 #include <QtGui/QPalette>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtCore/QCoreApplication>
 #include <QtCore/QTimer>
-#include <QRegularExpression>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
 
@@ -130,21 +132,21 @@ SeerMainWindow::SeerMainWindow(QWidget* parent) : QMainWindow(parent) {
     //
     // Set up signals/slots.
     //
-    QObject::connect(actionFileDebug,                   &QAction::triggered,                            this,           &SeerMainWindow::handleFileDebugWithOutDefaultProject);
-    QObject::connect(actionFileArguments,               &QAction::triggered,                            this,           &SeerMainWindow::handleFileArguments);
-    QObject::connect(actionFileQuit,                    &QAction::triggered,                            this,           &SeerMainWindow::handleFileQuit);
-    QObject::connect(actionViewMemoryVisualizer,        &QAction::triggered,                            this,           &SeerMainWindow::handleViewMemoryVisualizer);
-    QObject::connect(actionViewArrayVisualizer,         &QAction::triggered,                            this,           &SeerMainWindow::handleViewArrayVisualizer);
-    QObject::connect(actionViewMatrixVisualizer,        &QAction::triggered,                            this,           &SeerMainWindow::handleViewMatrixVisualizer);
-    QObject::connect(actionViewStructVisualizer,        &QAction::triggered,                            this,           &SeerMainWindow::handleViewVarVisualizer);
-    QObject::connect(actionViewBasicStructVisualizer,   &QAction::triggered,                            this,           &SeerMainWindow::handleViewStructVisualizer);
-    QObject::connect(actionViewImageVisualizer,         &QAction::triggered,                            this,           &SeerMainWindow::handleViewImageVisualizer);
-    QObject::connect(actionViewGdbMonitor,              &QAction::triggered,                            this,           &SeerMainWindow::handleViewGdbMonitor);
-    QObject::connect(actionViewAssembly,                &QAction::triggered,                            this,           &SeerMainWindow::handleViewAssembly);
-    QObject::connect(actionConsoleAttached,             &QAction::triggered,                            this,           &SeerMainWindow::handleViewConsoleAttached);
-    QObject::connect(actionConsoleDetached,             &QAction::triggered,                            this,           &SeerMainWindow::handleViewConsoleDetached);
-    QObject::connect(actionConsoleDetachedMinimized,    &QAction::triggered,                            this,           &SeerMainWindow::handleViewConsoleDetachedMinimized);
-    QObject::connect(actionHelpAbout,                   &QAction::triggered,                            this,           &SeerMainWindow::handleHelpAbout);
+    QObject::connect(actionFileDebug,                   &QAction::triggered,                            this,                           &SeerMainWindow::handleFileDebugWithOutDefaultProject);
+    QObject::connect(actionFileArguments,               &QAction::triggered,                            this,                           &SeerMainWindow::handleFileArguments);
+    QObject::connect(actionFileQuit,                    &QAction::triggered,                            this,                           &SeerMainWindow::handleFileQuit);
+    QObject::connect(actionViewMemoryVisualizer,        &QAction::triggered,                            this,                           &SeerMainWindow::handleViewMemoryVisualizer);
+    QObject::connect(actionViewArrayVisualizer,         &QAction::triggered,                            this,                           &SeerMainWindow::handleViewArrayVisualizer);
+    QObject::connect(actionViewMatrixVisualizer,        &QAction::triggered,                            this,                           &SeerMainWindow::handleViewMatrixVisualizer);
+    QObject::connect(actionViewStructVisualizer,        &QAction::triggered,                            this,                           &SeerMainWindow::handleViewVarVisualizer);
+    QObject::connect(actionViewBasicStructVisualizer,   &QAction::triggered,                            this,                           &SeerMainWindow::handleViewStructVisualizer);
+    QObject::connect(actionViewImageVisualizer,         &QAction::triggered,                            this,                           &SeerMainWindow::handleViewImageVisualizer);
+    QObject::connect(actionViewGdbMonitor,              &QAction::triggered,                            this,                           &SeerMainWindow::handleViewGdbMonitor);
+    QObject::connect(actionViewAssembly,                &QAction::triggered,                            this,                           &SeerMainWindow::handleViewAssembly);
+    QObject::connect(actionConsoleAttached,             &QAction::triggered,                            this,                           &SeerMainWindow::handleViewConsoleAttached);
+    QObject::connect(actionConsoleDetached,             &QAction::triggered,                            this,                           &SeerMainWindow::handleViewConsoleDetached);
+    QObject::connect(actionConsoleDetachedMinimized,    &QAction::triggered,                            this,                           &SeerMainWindow::handleViewConsoleDetachedMinimized);
+    QObject::connect(actionHelpAbout,                   &QAction::triggered,                            this,                           &SeerMainWindow::handleHelpAbout);
 
     QObject::connect(actionControlRestart,              &QAction::triggered,                            this,                           &SeerMainWindow::handleRestartExecutable);
     QObject::connect(actionControlTerminate,            &QAction::triggered,                            this,                           &SeerMainWindow::handleTerminateExecutable);
@@ -167,62 +169,68 @@ SeerMainWindow::SeerMainWindow(QWidget* parent) : QMainWindow(parent) {
     QObject::connect(actionControlRecordStop,           &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbRecordStop);
     QObject::connect(actionControlInterrupt,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterrupt);
 
-    QObject::connect(actionSettingsConfiguration,       &QAction::triggered,                            this,           &SeerMainWindow::handleSettingsConfiguration);
-    QObject::connect(actionSettingsSaveConfiguration,   &QAction::triggered,                            this,           &SeerMainWindow::handleSettingsSaveConfiguration);
+    QObject::connect(actionSettingsConfiguration,       &QAction::triggered,                            this,                           &SeerMainWindow::handleSettingsConfiguration);
+    QObject::connect(actionSettingsSaveConfiguration,   &QAction::triggered,                            this,                           &SeerMainWindow::handleSettingsSaveConfiguration);
 
-    QObject::connect(actionGdbLaunch,                   &QAction::triggered,                            this,           &SeerMainWindow::handleFileDebugWithOutDefaultProject);
-    QObject::connect(actionGdbTerminate,                &QAction::triggered,                            this,           &SeerMainWindow::handleTerminateExecutable);
-    QObject::connect(actionGdbRestart,                  &QAction::triggered,                            this,           &SeerMainWindow::handleRestartExecutable);
-    QObject::connect(_styleMenuActionGroup,             &QActionGroup::triggered,                       this,           &SeerMainWindow::handleStyleMenuChanged);
-    QObject::connect(actionGdbContinue,                 &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbContinue);
-    QObject::connect(actionGdbNext,                     &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbNext);
-    QObject::connect(actionGdbStep,                     &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbStep);
-    QObject::connect(actionGdbNexti,                    &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbNexti);
-    QObject::connect(actionGdbStepi,                    &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbStepi);
-    QObject::connect(actionGdbFinish,                   &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbFinish);
-    QObject::connect(actionRecordProcess,               &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbRecordStartStopToggle);
-    QObject::connect(actionRecordDirection,             &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbRecordDirectionToggle);
+    QObject::connect(actionGdbLaunch,                   &QAction::triggered,                            this,                           &SeerMainWindow::handleFileDebugWithOutDefaultProject);
+    QObject::connect(actionGdbTerminate,                &QAction::triggered,                            this,                           &SeerMainWindow::handleTerminateExecutable);
+    QObject::connect(actionGdbRestart,                  &QAction::triggered,                            this,                           &SeerMainWindow::handleRestartExecutable);
+    QObject::connect(_styleMenuActionGroup,             &QActionGroup::triggered,                       this,                           &SeerMainWindow::handleStyleMenuChanged);
+    QObject::connect(actionGdbContinue,                 &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbContinue);
+    QObject::connect(actionGdbNext,                     &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbNext);
+    QObject::connect(actionGdbStep,                     &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbStep);
+    QObject::connect(actionGdbNexti,                    &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbNexti);
+    QObject::connect(actionGdbStepi,                    &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbStepi);
+    QObject::connect(actionGdbFinish,                   &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbFinish);
+    QObject::connect(actionRecordProcess,               &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbRecordStartStopToggle);
+    QObject::connect(actionRecordDirection,             &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbRecordDirectionToggle);
 
-    QObject::connect(actionInterruptProcess,            &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbInterrupt);
-    QObject::connect(_interruptAction,                  &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbInterrupt);
-    QObject::connect(interruptActionSIGINT,             &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbInterruptSIGINT);
-    QObject::connect(interruptActionSIGKILL,            &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbInterruptSIGKILL);
-    QObject::connect(interruptActionSIGFPE,             &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbInterruptSIGFPE);
-    QObject::connect(interruptActionSIGSEGV,            &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbInterruptSIGSEGV);
-    QObject::connect(interruptActionSIGUSR1,            &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbInterruptSIGUSR1);
-    QObject::connect(interruptActionSIGUSR2,            &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbInterruptSIGUSR2);
+    QObject::connect(actionInterruptProcess,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterrupt);
+    QObject::connect(_interruptAction,                  &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterrupt);
+    QObject::connect(interruptActionSIGINT,             &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterruptSIGINT);
+    QObject::connect(interruptActionSIGKILL,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterruptSIGKILL);
+    QObject::connect(interruptActionSIGFPE,             &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterruptSIGFPE);
+    QObject::connect(interruptActionSIGSEGV,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterruptSIGSEGV);
+    QObject::connect(interruptActionSIGUSR1,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterruptSIGUSR1);
+    QObject::connect(interruptActionSIGUSR2,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterruptSIGUSR2);
 
-    QObject::connect(actionVisualizers,                 &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbMemoryVisualizer);
-    QObject::connect(visualizerMemoryAction,            &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbMemoryVisualizer);
-    QObject::connect(visualizerArrayAction,             &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbArrayVisualizer);
-    QObject::connect(visualizerMatrixAction,            &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbMatrixVisualizer);
-    QObject::connect(visualizerVarAction,               &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbVarVisualizer);
-    QObject::connect(visualizerStructAction,            &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbStructVisualizer);
-    QObject::connect(visualizerImageAction,             &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbImageVisualizer);
-    QObject::connect(visualizerGdbMonitorAction,        &QAction::triggered,                            gdbWidget,      &SeerGdbWidget::handleGdbMonitor);
+    QObject::connect(actionVisualizers,                 &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbMemoryVisualizer);
+    QObject::connect(visualizerMemoryAction,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbMemoryVisualizer);
+    QObject::connect(visualizerArrayAction,             &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbArrayVisualizer);
+    QObject::connect(visualizerMatrixAction,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbMatrixVisualizer);
+    QObject::connect(visualizerVarAction,               &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbVarVisualizer);
+    QObject::connect(visualizerStructAction,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbStructVisualizer);
+    QObject::connect(visualizerImageAction,             &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbImageVisualizer);
+    QObject::connect(visualizerGdbMonitorAction,        &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbMonitor);
 
-    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::astrixTextOutput,                  runStatus,      &SeerRunStatusIndicator::handleText);
-    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::equalTextOutput,                   runStatus,      &SeerRunStatusIndicator::handleText);
-    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::astrixTextOutput,                  this,           &SeerMainWindow::handleText);
-    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::caretTextOutput,                   this,           &SeerMainWindow::handleText);
-    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::equalTextOutput,                   this,           &SeerMainWindow::handleText);
-    QObject::connect(gdbWidget->editorManager(),        &SeerEditorManagerWidget::showMessage,          this,           &SeerMainWindow::handleShowMessage);
-    QObject::connect(gdbWidget->editorManager(),        &SeerEditorManagerWidget::assemblyTabShown,     this,           &SeerMainWindow::handleViewAssemblyShown);
+    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::astrixTextOutput,                  runStatus,                      &SeerRunStatusIndicator::handleText);
+    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::equalTextOutput,                   runStatus,                      &SeerRunStatusIndicator::handleText);
+    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::astrixTextOutput,                  this,                           &SeerMainWindow::handleText);
+    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::caretTextOutput,                   this,                           &SeerMainWindow::handleText);
+    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::equalTextOutput,                   this,                           &SeerMainWindow::handleText);
+    QObject::connect(gdbWidget->editorManager(),        &SeerEditorManagerWidget::showMessage,          this,                           &SeerMainWindow::handleShowMessage);
+    QObject::connect(gdbWidget->editorManager(),        &SeerEditorManagerWidget::assemblyTabShown,     this,                           &SeerMainWindow::handleViewAssemblyShown);
 
-    QObject::connect(gdbWidget,                         &SeerGdbWidget::recordSettingsChanged,          this,           &SeerMainWindow::handleRecordSettingsChanged);
-    QObject::connect(gdbWidget,                         &SeerGdbWidget::changeWindowTitle,              this,           &SeerMainWindow::handleChangeWindowTitle);
-    QObject::connect(gdbWidget,                         &SeerGdbWidget::stateChanged,                   this,           &SeerMainWindow::handleGdbStateChanged);
+    QObject::connect(gdbWidget,                         &SeerGdbWidget::recordSettingsChanged,          this,                           &SeerMainWindow::handleRecordSettingsChanged);
+    QObject::connect(gdbWidget,                         &SeerGdbWidget::changeWindowTitle,              this,                           &SeerMainWindow::handleChangeWindowTitle);
+    QObject::connect(gdbWidget,                         &SeerGdbWidget::stateChanged,                   this,                           &SeerMainWindow::handleGdbStateChanged);
 
-    QObject::connect(runStatus,                         &SeerRunStatusIndicator::statusChanged,         this,           &SeerMainWindow::handleRunStatusChanged);
-    QObject::connect(qApp,                              &QApplication::aboutToQuit,                     gdbWidget,      &SeerGdbWidget::handleGdbShutdown);
+    QObject::connect(runStatus,                         &SeerRunStatusIndicator::statusChanged,         this,                           &SeerMainWindow::handleRunStatusChanged);
+    QObject::connect(qApp,                              &QApplication::aboutToQuit,                     gdbWidget,                      &SeerGdbWidget::handleGdbShutdown);
 
-    QObject::connect(helpToolButton,                    &QToolButton::clicked,                          this,           &SeerMainWindow::handleHelpToolButtonClicked);
+    QObject::connect(helpToolButton,                    &QToolButton::clicked,                          this,                           &SeerMainWindow::handleHelpToolButtonClicked);
 
-    QObject::connect(gdbWidget,                         &SeerGdbWidget::sessionTerminated,              runStatus,      &SeerRunStatusIndicator::handleSessionTerminated);
+    QObject::connect(gdbWidget,                         &SeerGdbWidget::sessionTerminated,              runStatus,                      &SeerRunStatusIndicator::handleSessionTerminated);
 
     // This handle button state when target state changes
-    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::astrixTextOutput,                  this,           &SeerMainWindow::handleStatusChanged);
-    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::caretTextOutput,                   this,           &SeerMainWindow::handleStatusChanged);
+    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::astrixTextOutput,                  this,                           &SeerMainWindow::handleStatusChanged);
+    QObject::connect(gdbWidget->gdbMonitor(),           &GdbMonitor::caretTextOutput,                   this,                           &SeerMainWindow::handleStatusChanged);
+
+    // Handle when theme is changed. Change the color of all icons.
+    QObject::connect(QGuiApplication::styleHints(),     &QStyleHints::colorSchemeChanged,               this,                           &SeerMainWindow::handleThemeChanged);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     handleRecordSettingsChanged();
 
@@ -2133,5 +2141,11 @@ void SeerMainWindow::handleGdbTargetInterrupt() {
     actionGdbFinish->setEnabled(true);
     actionGdbNexti->setEnabled(true);
     actionGdbStepi->setEnabled(true);
+}
+
+void SeerMainWindow::handleThemeChanged () {
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 }
 

--- a/src/SeerMainWindow.h
+++ b/src/SeerMainWindow.h
@@ -111,6 +111,7 @@ class SeerMainWindow : public QMainWindow, protected Ui::SeerMainWindowForm {
         void                        handleGdbTargetRunning                  ();
         void                        handleGdbTargetInterrupt                ();
         void                        handleStatusChanged                     (QString message);
+        void                        handleThemeChanged                      ();
 
     protected:
         void                        writeSettings                           ();

--- a/src/SeerMatrixVisualizerWidget.cpp
+++ b/src/SeerMatrixVisualizerWidget.cpp
@@ -9,7 +9,8 @@
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QToolTip>
 #include <QtGui/QIntValidator>
-#include <QtGui/QIcon>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtPrintSupport/QPrinter>
 #include <QtPrintSupport/QPrintDialog>
 #include <QtCore/QRegularExpression>
@@ -33,7 +34,6 @@ SeerMatrixVisualizerWidget::SeerMatrixVisualizerWidget (QWidget* parent) : QWidg
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Matrix Visualizer");
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -58,6 +58,10 @@ SeerMatrixVisualizerWidget::SeerMatrixVisualizerWidget (QWidget* parent) : QWidg
     QObject::connect(matrixStrideLineEdit,          &SeerHistoryLineEdit::editingFinished,                     this,            &SeerMatrixVisualizerWidget::handleElementStrideLineEdit);
     QObject::connect(matrixDisplayFormatComboBox,   QOverload<int>::of(&QComboBox::currentIndexChanged),       this,            &SeerMatrixVisualizerWidget::handleMatrixDisplayFormatComboBox);
     QObject::connect(matrixTableWidget,             &SeerMatrixWidget::dataChanged,                            this,            &SeerMatrixVisualizerWidget::handleDataChanged);
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,                          this,            &SeerMatrixVisualizerWidget::handleThemeChanged);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     // Restore window settings.
     readSettings();
@@ -634,6 +638,12 @@ void SeerMatrixVisualizerWidget::handleDataChanged () {
     medianLineEdit->setText(QString::number(med));
 
     return;
+}
+
+void SeerMatrixVisualizerWidget::handleThemeChanged () {
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 }
 
 void SeerMatrixVisualizerWidget::writeSettings() {

--- a/src/SeerMatrixVisualizerWidget.h
+++ b/src/SeerMatrixVisualizerWidget.h
@@ -46,6 +46,7 @@ class SeerMatrixVisualizerWidget : public QWidget, protected Ui::SeerMatrixVisua
         void                handleElementStrideLineEdit             ();
         void                handleMatrixDisplayFormatComboBox       (int index);
         void                handleDataChanged                       ();
+        void                handleThemeChanged                      ();
 
     protected:
         void                writeSettings                           ();

--- a/src/SeerMemoryVisualizerWidget.cpp
+++ b/src/SeerMemoryVisualizerWidget.cpp
@@ -8,7 +8,8 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QFileDialog>
 #include <QtGui/QIntValidator>
-#include <QtGui/QIcon>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtPrintSupport/QPrinter>
 #include <QtPrintSupport/QPrintDialog>
 #include <QtCore/QRegularExpression>
@@ -28,7 +29,6 @@ SeerMemoryVisualizerWidget::SeerMemoryVisualizerWidget (QWidget* parent) : QWidg
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Memory Visualizer");
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -72,6 +72,10 @@ SeerMemoryVisualizerWidget::SeerMemoryVisualizerWidget (QWidget* parent) : QWidg
     QObject::connect(columnCountSpinBox,            QOverload<int>::of(&QSpinBox::valueChanged),               this,                    &SeerMemoryVisualizerWidget::handleColumnCountSpinBox);
     QObject::connect(printToolButton,               &QToolButton::clicked,                                     this,                    &SeerMemoryVisualizerWidget::handlePrintButton);
     QObject::connect(saveToolButton,                &QToolButton::clicked,                                     this,                    &SeerMemoryVisualizerWidget::handleSaveButton);
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,                          this,                    &SeerMemoryVisualizerWidget::handleThemeChanged);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     // Restore window settings.
     readSettings();
@@ -484,6 +488,12 @@ void SeerMemoryVisualizerWidget::handleSaveButton () {
         QMessageBox::critical(this, tr("Error"), tr("Cannot save display to file."));
         return;
     }
+}
+
+void SeerMemoryVisualizerWidget::handleThemeChanged () {
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 }
 
 void SeerMemoryVisualizerWidget::writeSettings() {

--- a/src/SeerMemoryVisualizerWidget.h
+++ b/src/SeerMemoryVisualizerWidget.h
@@ -40,6 +40,7 @@ class SeerMemoryVisualizerWidget : public QWidget, protected Ui::SeerMemoryVisua
         void                handleColumnCountSpinBox            (int value);
         void                handlePrintButton                   ();
         void                handleSaveButton                    ();
+        void                handleThemeChanged                  ();
 
     protected:
         void                writeSettings                       ();

--- a/src/SeerMessagesBrowserWidget.cpp
+++ b/src/SeerMessagesBrowserWidget.cpp
@@ -18,16 +18,7 @@ SeerMessagesBrowserWidget::SeerMessagesBrowserWidget (QWidget* parent) : QWidget
     setupUi(this);
 
     // Setup the widgets
-    QString style = "QTreeWidget::item:!selected "          // Items in tree widget will have a border.
-                    "{ "
-                       "border: 1px solid gainsboro; "
-                       "border-left: none; "
-                       "border-top: none; "
-                    "}"
-                    "QTreeWidget::item:selected {}";
-
     messagesTreeWidget->setRootIsDecorated(false);
-    messagesTreeWidget->setStyleSheet(style);
     messagesTreeWidget->setSortingEnabled(false);
     messagesTreeWidget->resizeColumnToContents(0); // timestamp
     messagesTreeWidget->resizeColumnToContents(1); // message type icon

--- a/src/SeerMessagesDialog.cpp
+++ b/src/SeerMessagesDialog.cpp
@@ -19,7 +19,6 @@ SeerMessagesDialog::SeerMessagesDialog (QWidget* parent) : QDialog(parent) {
     // Construct the UI.
     setupUi(this);
 
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Execution Messages");
 
     // Setup the widgets.

--- a/src/SeerRegisterEditValueDialog.ui
+++ b/src/SeerRegisterEditValueDialog.ui
@@ -13,10 +13,6 @@
   <property name="windowTitle">
    <string>Seer - Edit a Register Value</string>
   </property>
-  <property name="windowIcon">
-   <iconset>
-    <normaloff>resources/icons/hicolor/32x32/seergdb.png</normaloff>resources/icons/hicolor/32x32/seergdb.png</iconset>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="breakpointLocationGroupBox">

--- a/src/SeerSignalEditValueDialog.ui
+++ b/src/SeerSignalEditValueDialog.ui
@@ -13,10 +13,6 @@
   <property name="windowTitle">
    <string>Seer - Edit a Signal Value</string>
   </property>
-  <property name="windowIcon">
-   <iconset>
-    <normaloff>resources/icons/hicolor/32x32/seergdb.png</normaloff>resources/icons/hicolor/32x32/seergdb.png</iconset>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="signalGroupBox">

--- a/src/SeerSlashProcDialog.ui
+++ b/src/SeerSlashProcDialog.ui
@@ -13,10 +13,6 @@
   <property name="windowTitle">
    <string>Seer - System Processes</string>
   </property>
-  <property name="windowIcon">
-   <iconset resource="resource.qrc">
-    <normaloff>:/seer/resources/icons/hicolor/32x32/seergdb.png</normaloff>:/seer/resources/icons/hicolor/32x32/seergdb.png</iconset>
-  </property>
   <property name="toolTip">
    <string>Select a process pid.</string>
   </property>

--- a/src/SeerStructVisualizerWidget.cpp
+++ b/src/SeerStructVisualizerWidget.cpp
@@ -9,7 +9,8 @@
 #include <QtWidgets/QTreeWidgetItemIterator>
 #include <QtWidgets/QMenu>
 #include <QAction>
-#include <QtGui/QIcon>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QTime>
 #include <QtCore/QSettings>
@@ -24,7 +25,6 @@ SeerStructVisualizerWidget::SeerStructVisualizerWidget (QWidget* parent) : QWidg
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Basic Struct Visualizer");
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -39,13 +39,17 @@ SeerStructVisualizerWidget::SeerStructVisualizerWidget (QWidget* parent) : QWidg
     variableTreeWidget->clear();
 
     // Connect things.
-    QObject::connect(refreshToolButton,      &QToolButton::clicked,                       this,  &SeerStructVisualizerWidget::handleRefreshButton);
-    QObject::connect(helpToolButton,         &QToolButton::clicked,                       this,  &SeerStructVisualizerWidget::handleHelpButton);
-    QObject::connect(variableNameLineEdit,   &QLineEdit::returnPressed,                   this,  &SeerStructVisualizerWidget::handleVariableNameLineEdit);
-    QObject::connect(variableTreeWidget,     &QTreeWidget::customContextMenuRequested,    this,  &SeerStructVisualizerWidget::handleContextMenu);
-    QObject::connect(variableTreeWidget,     &QTreeWidget::itemEntered,                   this,  &SeerStructVisualizerWidget::handleItemEntered);
-    QObject::connect(variableTreeWidget,     &QTreeWidget::itemExpanded,                  this,  &SeerStructVisualizerWidget::handleItemExpanded);
-    QObject::connect(variableTreeWidget,     &QTreeWidget::itemCollapsed,                 this,  &SeerStructVisualizerWidget::handleItemExpanded);
+    QObject::connect(refreshToolButton,             &QToolButton::clicked,                       this,  &SeerStructVisualizerWidget::handleRefreshButton);
+    QObject::connect(helpToolButton,                &QToolButton::clicked,                       this,  &SeerStructVisualizerWidget::handleHelpButton);
+    QObject::connect(variableNameLineEdit,          &QLineEdit::returnPressed,                   this,  &SeerStructVisualizerWidget::handleVariableNameLineEdit);
+    QObject::connect(variableTreeWidget,            &QTreeWidget::customContextMenuRequested,    this,  &SeerStructVisualizerWidget::handleContextMenu);
+    QObject::connect(variableTreeWidget,            &QTreeWidget::itemEntered,                   this,  &SeerStructVisualizerWidget::handleItemEntered);
+    QObject::connect(variableTreeWidget,            &QTreeWidget::itemExpanded,                  this,  &SeerStructVisualizerWidget::handleItemExpanded);
+    QObject::connect(variableTreeWidget,            &QTreeWidget::itemCollapsed,                 this,  &SeerStructVisualizerWidget::handleItemExpanded);
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,            this,  &SeerStructVisualizerWidget::handleThemeChanged);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     // Restore window settings.
     readSettings();
@@ -498,6 +502,12 @@ void SeerStructVisualizerWidget::handleVariableNameLineEdit () {
     }
 
     setVariableName (variableNameLineEdit->text());
+}
+
+void SeerStructVisualizerWidget::handleThemeChanged () {
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 }
 
 void SeerStructVisualizerWidget::writeSettings () {

--- a/src/SeerStructVisualizerWidget.h
+++ b/src/SeerStructVisualizerWidget.h
@@ -35,6 +35,7 @@ class SeerStructVisualizerWidget : public QWidget, protected Ui::SeerStructVisua
         void                handleContextMenu                   (const QPoint&    pos);
         void                handleItemEntered                   (QTreeWidgetItem* item, int column);
         void                handleItemExpanded                  (QTreeWidgetItem* item);
+        void                handleThemeChanged                  ();
 
     protected:
         void                handleItemCreate                    (QTreeWidgetItem* parentItem, const QString& value_text);

--- a/src/SeerUtl.cpp
+++ b/src/SeerUtl.cpp
@@ -3,14 +3,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "SeerUtl.h"
+#include <QtCharts/QChartView>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QAbstractButton>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMainWindow>
+#include <QtWidgets/QApplication>
+#include <QtGui/QColor>
+#include <QtGui/QIcon>
+#include <QtGui/QPainter>
+#include <QtGui/QPixmap>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
+#include <QtCore/QDir>
 #include <QtCore/QFile>
 #include <QtCore/QString>
 #include <QtCore/QDebug>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QRegularExpressionMatch>
 #include <QtCore/QByteArray>
-#include <QtWidgets/QMessageBox>
-#include <QDir>
 
 // Comment out for now. I don't want to include boost because
 // that would impact people try to compile Seer. Qt6 offer
@@ -1368,6 +1379,134 @@ namespace Seer {
             QMessageBox::warning(nullptr, "Seer", QString("Directory %1 doesn't exist.").arg(dirname), QMessageBox::Ok);
             return false;
         }
+    }
+
+    void colorizeAllIcons (QWidget* parent, const QSize& size) {
+
+        if (parent == nullptr) {
+            return;
+        }
+
+        // Get the current color scheme
+        Qt::ColorScheme colorScheme = QGuiApplication::styleHints()->colorScheme();
+
+        // Look for all button types.
+        const auto buttons = parent->findChildren<QAbstractButton*>();
+
+        for (QAbstractButton* button : buttons) {
+
+            if (colorScheme == Qt::ColorScheme::Dark) {
+                button->setIcon(Seer::colorizeIcon(button->icon(), QColor("white"), size));
+            }else{
+                button->setIcon(Seer::colorizeIcon(button->icon(), QColor("black"), size));
+            }
+        }
+
+        // Look for all menu types.
+        const auto menus = parent->findChildren<QMenu*>();
+
+        for (QMenu* menu : menus) {
+
+            if (colorScheme == Qt::ColorScheme::Dark) {
+                menu->setIcon(Seer::colorizeIcon(menu->icon(), QColor("white"), size));
+            }else{
+                menu->setIcon(Seer::colorizeIcon(menu->icon(), QColor("black"), size));
+            }
+        }
+
+        // Look for all action types.
+        const auto actions = parent->findChildren<QAction*>();
+
+        for (QAction* action : actions) {
+
+            if (colorScheme == Qt::ColorScheme::Dark) {
+                action->setIcon(Seer::colorizeIcon(action->icon(), QColor("white"), size));
+            }else{
+                action->setIcon(Seer::colorizeIcon(action->icon(), QColor("black"), size));
+            }
+        }
+
+        // Look for the app's titlebar icon.
+        // XXX Doesn't work!
+        // XXX Titlebar icon remains the same. It doesn't change. Don't know why.
+        if (colorScheme == Qt::ColorScheme::Dark) {
+            QApplication::setWindowIcon(Seer::colorizeIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"), QColor("white"), size));
+        }else{
+            QApplication::setWindowIcon(Seer::colorizeIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"), QColor("black"), size));
+        }
+    }
+
+    void colorizeListWidgetItemIcon (QListWidgetItem* item, const QSize& size) {
+
+        if (item == nullptr) {
+            return;
+        }
+
+        // Get the current color scheme
+        Qt::ColorScheme colorScheme = QGuiApplication::styleHints()->colorScheme();
+
+        if (colorScheme == Qt::ColorScheme::Dark) {
+            item->setIcon(Seer::colorizeIcon(item->icon(), QColor("white"), size));
+        }else{
+            item->setIcon(Seer::colorizeIcon(item->icon(), QColor("black"), size));
+        }
+    }
+
+    void colorizeChartViewItem (QChartView* item) {
+
+        if (item == nullptr) {
+            return;
+        }
+
+        QChart* chart = item->chart();
+
+        if (chart == nullptr) {
+            return;
+        }
+
+        // Get the current color scheme
+        Qt::ColorScheme colorScheme = QGuiApplication::styleHints()->colorScheme();
+
+        if (colorScheme == Qt::ColorScheme::Dark) {
+            chart->setTheme(QChart::ChartThemeDark);
+        }else{
+            chart->setTheme(QChart::ChartThemeLight);
+        }
+    }
+
+    QIcon colorizeIcon (const QIcon& icon, const QSize& size) {
+
+        // Get the current color scheme
+        Qt::ColorScheme colorScheme = QGuiApplication::styleHints()->colorScheme();
+
+        if (colorScheme == Qt::ColorScheme::Dark) {
+            return Seer::colorizeIcon(icon, QColor("white"), size);
+        }else{
+            return Seer::colorizeIcon(icon, QColor("black"), size);
+        }
+    }
+
+    QIcon colorizeIcon (const QIcon& icon, const QColor& color, const QSize& size) {
+
+        // Get the pixmap from the icon
+        QPixmap pixmap = icon.pixmap(size);
+
+        // Create a new pixmap with the same size and format (preserves alpha)
+        QPixmap whitePixmap(pixmap.size());
+        whitePixmap.fill(Qt::transparent);
+
+        QPainter painter(&whitePixmap);
+
+        // Draw the original pixmap
+        painter.drawPixmap(0, 0, pixmap);
+
+        // Use CompositionMode_SourceIn to colorize while keeping alpha
+        painter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+        painter.fillRect(whitePixmap.rect(), color);
+
+        painter.end();
+
+        return QIcon(whitePixmap);
     }
 }
 

--- a/src/SeerUtl.h
+++ b/src/SeerUtl.h
@@ -4,6 +4,11 @@
 
 #pragma once
 #include "QStringPair.h"
+#include <QtCharts/QChartView>
+#include <QtWidgets/QListWidgetItem>
+#include <QtGui/QColor>
+#include <QtGui/QIcon>
+#include <QtGui/QPixmap>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
 #include <QtCore/QMap>
@@ -62,5 +67,11 @@ namespace Seer {
     void                        printStackTrace     ();
     bool                        isFileExistNotify   (const QString& filename);
     bool                        isDirExistNotify    (const QString& dirname);
+
+    void                        colorizeAllIcons            (QWidget* parent, const QSize& size = QSize(32,32));
+    void                        colorizeListWidgetItemIcon  (QListWidgetItem* item, const QSize& size = QSize(32,32));
+    void                        colorizeChartViewItem       (QChartView* item);
+    QIcon                       colorizeIcon                (const QIcon& icon, const QSize& size = QSize(32,32));
+    QIcon                       colorizeIcon                (const QIcon& icon, const QColor& color, const QSize& size = QSize(32,32));
 }
 

--- a/src/SeerVarVisualizerWidget.cpp
+++ b/src/SeerVarVisualizerWidget.cpp
@@ -11,6 +11,8 @@
 #include <QtWidgets/QMenu>
 #include <QAction>
 #include <QtWidgets/QMessageBox>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QStyleHints>
 #include <QtGui/QIcon>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QTimer>
@@ -26,7 +28,6 @@ SeerVarVisualizerWidget::SeerVarVisualizerWidget (QWidget* parent) : QWidget(par
     setupUi(this);
 
     // Setup the widgets
-    setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     setWindowTitle("Seer Struct Visualizer");
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -69,7 +70,6 @@ SeerVarVisualizerWidget::SeerVarVisualizerWidget (QWidget* parent) : QWidget(par
     variableTreeWidget->setItemDelegateForColumn(8, new QNoEditDelegate(this));
     variableTreeWidget->setItemDelegateForColumn(9, new QNoEditDelegate(this));
 
-
     // Connect things.
     QObject::connect(refreshToolButton,             &QToolButton::clicked,                       this,  &SeerVarVisualizerWidget::handleRefreshButton);
     QObject::connect(helpToolButton,                &QToolButton::clicked,                       this,  &SeerVarVisualizerWidget::handleHelpButton);
@@ -83,6 +83,10 @@ SeerVarVisualizerWidget::SeerVarVisualizerWidget (QWidget* parent) : QWidget(par
     QObject::connect(collapseSelectedToolButton,    &QToolButton::clicked,                       this,  &SeerVarVisualizerWidget::handleCollapseSelected);
     QObject::connect(editDelegate,                  &QAllowEditDelegate::editingStarted,         this,  &SeerVarVisualizerWidget::handleIndexEditingStarted);
     QObject::connect(editDelegate,                  &QAllowEditDelegate::editingFinished,        this,  &SeerVarVisualizerWidget::handleIndexEditingFinished);
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,            this,  &SeerVarVisualizerWidget::handleThemeChanged);
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 
     // Show/hide columns.
     handleDebugCheckBox();
@@ -933,6 +937,12 @@ void SeerVarVisualizerWidget::handleIndexEditingFinished (const QModelIndex& ind
 
     // Emit the signal to change the varobj to the new value.
     emit varObjAssign(_variableId, item->text(3), value);
+}
+
+void SeerVarVisualizerWidget::handleThemeChanged () {
+
+    // Colorize icons for theme.
+    Seer::colorizeAllIcons(this);
 }
 
 QTreeWidgetItem* SeerVarVisualizerWidget::findItem (const QString& text, Qt::MatchFlags flags, int column) {

--- a/src/SeerVarVisualizerWidget.h
+++ b/src/SeerVarVisualizerWidget.h
@@ -49,6 +49,7 @@ class SeerVarVisualizerWidget : public QWidget, protected Ui::SeerVarVisualizerW
         void                handleCollapseSelected              ();
         void                handleResizeColumns                 ();
         void                handleHideDebugColumns              (bool flag);
+        void                handleThemeChanged                  ();
 
     protected:
         QTreeWidgetItem*    findItem                            (const QString& text, Qt::MatchFlags flags, int column);

--- a/src/seergdb.cpp
+++ b/src/seergdb.cpp
@@ -315,7 +315,6 @@ int main (int argc, char* argv[]) {
     //
     SeerMainWindow seer;
 
-    seer.setWindowIcon(QIcon(":/seer/resources/icons/hicolor/64x64/seergdb.png"));
     seer.setExecutableName(executableName);
     seer.setExecutableWorkingDirectory(executableWorkingDirectory);
     seer.setExecutableSymbolName(executableSymbolFilename);


### PR DESCRIPTION
I've found a happy method to manage Icons for dark and light themed desk tops.

Seer will require mono colored Icons, usually black icons.  When starting up, Seer will colorize all icons in the Qt object tree with the current theme (dark or light) that is detected.  Seer will also detect if the theme is changed if it is running. And it will colorize all icons then as well.

Some other Qt widgets need attending for individial cases (QChartView that is used in the Array Visualizer).

If the theme is changed while Seer is running, Seer will change the Editor's color scheme accordingly. This is temporary until one saves the configuration.