### PR TITLE
Array Visualizer: fix scatter markers rendering unstyled with large arrays

### DIFF
--- a/src/SeerArrayVisualizerWidget.cpp
+++ b/src/SeerArrayVisualizerWidget.cpp
@@ -24,6 +24,30 @@
 #include <QtCore/QDebug>
 #include <QtGlobal>
 
+//
+// Qt Charts 6.x workaround: scatter marker items can be (re)created without
+// inheriting the series' pen/brush, leaving near-invisible ~1px markers.
+// Small arrays usually render fine; large ones (e.g. 4000 points) reliably
+// degrade. The series-level state is correct in both cases (verified with an
+// instrumented build), so the style is lost at the marker-item level inside
+// Qt Charts. Because the series setters are guarded (a call with an unchanged
+// value is a no-op), we force two *actual* value transitions so the style is
+// pushed down to the marker items unconditionally.
+//
+static void redecorateScatterSeries (QXYSeries* series) {
+
+    QScatterSeries* scatter = qobject_cast<QScatterSeries*>(series);
+
+    if (scatter == nullptr) {
+        return;
+    }
+
+    scatter->setPen(QPen(Qt::transparent));
+    scatter->setBrush(QBrush(Qt::transparent));
+    scatter->setPen(QPen(Qt::NoPen));
+    scatter->setBrush(QBrush(QColor(31, 119, 180)));
+}
+
 SeerArrayVisualizerWidget::SeerArrayVisualizerWidget (QWidget* parent) : QWidget(parent) {
 
     // Init variables.
@@ -983,6 +1007,7 @@ void SeerArrayVisualizerWidget::handleDataChanged () {
 
         arrayChartView->chart()->addSeries(_aSeries);
         arrayChartView->chart()->createDefaultAxes();
+        redecorateScatterSeries(_aSeries);
     }
 
     if (_bSeries) {
@@ -990,6 +1015,7 @@ void SeerArrayVisualizerWidget::handleDataChanged () {
 
         arrayChartView->chart()->addSeries(_bSeries);
         arrayChartView->chart()->createDefaultAxes();
+        redecorateScatterSeries(_bSeries);
     }
 
     // Zoom out slightly to allow for text label at edges.

--- a/tests/hello481/breakpoints.seer
+++ b/tests/hello481/breakpoints.seer
@@ -1,1 +1,1 @@
-break -source /nas/erniep/Development/seer/tests/hello481/hello481.cpp -line 17
+break -source /nas/erniep/Development/seer/tests/hello481/hello481.cpp -line 81

--- a/tests/hello481/hello481.cpp
+++ b/tests/hello481/hello481.cpp
@@ -1,18 +1,91 @@
-#include <string>
+// damped_oscillator
+//
+// Simulates a damped harmonic oscillator:
+//     x'' + 2*zeta*omega0*x' + omega0^2*x = 0
+//
+// Stores a 4000-point dataset directly into two double arrays:
+//     X[i] = position at step i
+//     Y[i] = velocity at step i
+//
+
 #include <iostream>
+#include <cmath>
+#include <iomanip>
 
-int main () {
+const int N = 4000;   // number of data points
 
-    double pos[40];
-    double vit[40];
+double X[N];  // position array
+double Y[N];  // velocity array
 
-    double posv = 1.0;
+struct State {
+    double x;  // position
+    double v;  // velocity
+};
 
-    for (int i=0; i<sizeof(pos); i++) {
+class DampedOscillator {
+    public:
+        DampedOscillator(double omega0, double zeta) : omega0_(omega0), zeta_(zeta) {}
 
-        pos[i] = posv;
-        posv -= (1.0 - 0.0) / double(sizeof(pos));
+        // dx/dt, dv/dt
+        State derivatives(const State& s) const {
+            State d;
+            d.x = s.v;
+            d.v = -2.0 * zeta_ * omega0_ * s.v - omega0_ * omega0_ * s.x;
+            return d;
+        }
+
+        // Single RK4 step
+        State step(const State& s, double dt) const {
+            State k1 = derivatives(s);
+
+            State s2{ s.x + 0.5 * dt * k1.x, s.v + 0.5 * dt * k1.v };
+            State k2 = derivatives(s2);
+
+            State s3{ s.x + 0.5 * dt * k2.x, s.v + 0.5 * dt * k2.v };
+            State k3 = derivatives(s3);
+
+            State s4{ s.x + dt * k3.x, s.v + dt * k3.v };
+            State k4 = derivatives(s4);
+
+            State result;
+            result.x = s.x + (dt / 6.0) * (k1.x + 2.0 * k2.x + 2.0 * k3.x + k4.x);
+            result.v = s.v + (dt / 6.0) * (k1.v + 2.0 * k2.v + 2.0 * k3.v + k4.v);
+            return result;
+        }
+
+    private:
+        double omega0_; // natural angular frequency (rad/s)
+        double zeta_;   // damping ratio (0 = undamped, 1 = critically damped)
+};
+
+int main() {
+
+    // ---- Simulation parameters (tweak as you like) ----
+    const double dt      = 0.01;   // time step (s)
+    const double omega0  = 2.0;    // natural angular frequency (rad/s)
+    const double zeta    = 0.05;   // damping ratio (underdamped)
+    const double x0      = 1.0;    // initial position
+    const double v0      = 0.0;    // initial velocity
+
+    DampedOscillator osc(omega0, zeta);
+    State state{ x0, v0 };
+
+    // Fill the arrays instead of writing to a file
+    for (int i = 0; i < N; ++i) {
+        X[i] = state.x;
+        Y[i] = state.v;
+        state = osc.step(state, dt);
     }
+
+    // Optional: print a few samples to confirm it worked
+    std::cout << std::fixed << std::setprecision(6);
+    std::cout << "First 5 points (X = position, Y = velocity):\n";
+
+    for (int i = 0; i < 5; ++i) {
+        std::cout << "  X[" << i << "]=" << X[i] << "  Y[" << i << "]=" << Y[i] << "\n";
+    }
+
+    std::cout << "Last point: X[" << N-1 << "]=" << X[N-1] << "  Y[" << N-1 << "]=" << Y[N-1] << "\n";
 
     return 0;
 }


### PR DESCRIPTION
### Problem

In scatter mode, marker items can render as tiny, nearly invisible
unstyled dots instead of the configured 7-px themed rectangles. Small
arrays (e.g. 100 elements) usually render fine; large arrays (e.g. 4000
elements) reliably degrade. This addresses the remaining case of #481.

### Root cause

Investigation with an instrumented build showed that the QScatterSeries
itself always ends up with the correct pen and brush. The problem occurs
when Qt Charts recreates the underlying marker items: depending on
dataset size, the recreated marker graphics do not inherit the current
series styling. Consistently reproducible on Qt Charts 6.4.2 with large
datasets. This appears to be a Qt Charts behavior rather than an issue
in Seer itself.

### Fix

After each `addSeries()` call, force two actual pen/brush transitions
(transparent, then the final style). Since the series setters ignore
calls with unchanged values, simply reassigning the current style is a
no-op; two real transitions guarantee the styling propagates to the
marker items regardless of how they were created. Line and spline
series are unaffected (the helper is a no-op for them).

Note: the markers get a deterministic color (#1f77b4) rather than the
theme color — theme decoration timing is part of the behavior being
worked around, so reading the theme color back at this point is not
reliable. Happy to switch to any preferred color.

### Testing

Tested on:

- Qt 6.4.2
- Linux Mint 22.3

Verified with:

- 100-point dataset (parabola)
- 4000-point dataset (damped oscillator, position/velocity)
- repeated refreshes
- X/Y scatter mode

Commenting out the new `redecorateScatterSeries()` calls immediately
restores the rendering issue.