### PR TITLE
Don't paint the progress indicator when it is stopped

### DIFF
--- a/src/QProgressIndicator.cpp
+++ b/src/QProgressIndicator.cpp
@@ -44,6 +44,7 @@ void QProgressIndicator::paintEvent(QPaintEvent* e) {
     if (!_timer->isActive()) {
         _angle = 0;
         _scale = 0.0f;
+        return; // Draw nothing when stopped. stop() expects the indicator to be erased from the view.
     }
 
     QPainter painter(this);


### PR DESCRIPTION
  **Summary**

  The activity/progress indicator in the toolbar stays visible — frozen at
  angle 0 — while gdb is idle: from startup until the first run, and again
  after every stop.

<img width="1920" height="1080" alt="Capture d’écran du 2026-07-20 15-02-39" src="https://github.com/user-attachments/assets/accebd56-dc28-449e-8ce0-4e3459a7023b" />

  **Cause**

  `stop()` states its intent in its own comment:

  ```cpp
  void QProgressIndicator::stop() {
      _timer->stop();
      update(); // Force an update to erase the indicator from the view.
  }
  ```

  but paintEvent() doesn't honor it — when the timer is inactive it merely
  resets _angle/_scale to 0 and then draws the indicator anyway, so the
  "erasing" update actually repaints a frozen spinner.

  Fix

  Return early from paintEvent() when the timer is stopped, so nothing is
  drawn and the widget shows its parent background when idle — which is what
  the stop() comment intended. The spinner still appears and animates while
  a program is running.

  Tested on a Qt6 build (Linux): indicator is absent at rest, spins during
  execution (e.g. seergdb --run /bin/sleep 5), and disappears on stop.

<img width="1920" height="1080" alt="Capture d’écran du 2026-07-20 15-09-54" src="https://github.com/user-attachments/assets/ab97cebc-66ff-499e-8e58-c322b0bbca2c" />


