### PR TITLE
Decode console output as UTF-8 instead of Latin-1

### DIFF
--- a/src/SeerConsoleWidget.cpp
+++ b/src/SeerConsoleWidget.cpp
@@ -89,7 +89,11 @@ void SeerConsoleWidget::handleText (const char* buffer, int count) {
     }
 
     // Write text to Ansi widget.
-    QString str = QString::fromLatin1(buffer, count);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QString str = _utf8Decoder.decode(QByteArrayView(buffer, count));
+#else
+    QString str = QString::fromUtf8(buffer, count);
+#endif
 
     textEdit->insertAnsiText(str);
     textEdit->ensureCursorVisible();

--- a/src/SeerConsoleWidget.h
+++ b/src/SeerConsoleWidget.h
@@ -10,6 +10,9 @@
 #include <QtGui/QShowEvent>
 #include <QtCore/QString>
 #include <QtCore/QSocketNotifier>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtCore/QStringConverter>
+#endif
 #include "ui_SeerConsoleWidget.h"
 
 class SeerConsoleWidget : public QWidget, protected Ui::SeerConsoleWidgetForm {
@@ -73,5 +76,8 @@ class SeerConsoleWidget : public QWidget, protected Ui::SeerConsoleWidgetForm {
         QSocketNotifier*    _ttyListener;
         bool                _enableStdout;
         bool                _enableWrap;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QStringDecoder      _utf8Decoder{QStringConverter::Utf8}; // Keeps state across reads so multi-byte sequences split by the 1024-byte buffer decode correctly.
+#endif
 };
 


### PR DESCRIPTION
  Fixes the console garbling reported in #489.

  Program output read from the pty was decoded with `QString::fromLatin1`
  (`SeerConsoleWidget.cpp`), so any non-ASCII UTF-8 written by the debugged
  program was garbled in the **Console output** tab — e.g. `Café` shown as
  `CafÃ©`. Only the console was affected; the source editor already decodes
  UTF-8 correctly.

<img width="2560" height="1400" alt="Capture d’écran du 2026-07-22 16-13-22" src="https://github.com/user-attachments/assets/90707ca9-a3ef-46c2-beb5-b5078e30e6de" />

  **Change**

  Decode the bytes as UTF-8. The pty is read in 1024-byte chunks
  (`handleTerminalOutput`), so a multi-byte sequence can straddle two reads;
  a plain per-chunk `QString::fromUtf8()` would emit a replacement character
  at the boundary. On Qt6 a persistent `QStringDecoder` member keeps the
  decoding state across reads so those bytes decode correctly. Qt5 falls back
  to `QString::fromUtf8`.

  **Testing**

  - `printf("Café, déjà vu — €10 — 日本語\n")` in a program run under
    `seergdb --start`: Console output now shows the text correctly.
  - Verified the persistent decoder against a multi-byte sequence split across
    three separate `decode()` calls — it reassembles correctly, whereas
    per-chunk `fromUtf8` does not.

<img width="1764" height="1056" alt="Capture d’écran du 2026-07-23 21-31-11" src="https://github.com/user-attachments/assets/853989c8-4c47-432a-b75a-5c2cca8a2abe" />

  Built and run on Qt6 / Linux.