### PR TITLE
Add a row-major/column-major selector to the Matrix Visualizer

### DIFF
--- a/src/SeerMatrixVisualizerWidget.cpp
+++ b/src/SeerMatrixVisualizerWidget.cpp
@@ -40,8 +40,10 @@ SeerMatrixVisualizerWidget::SeerMatrixVisualizerWidget (QWidget* parent) : QWidg
     setAttribute(Qt::WA_DeleteOnClose);
 
     matrixDisplayFormatComboBox->setCurrentIndex(0);
+    matrixStorageOrderComboBox->setCurrentIndex(0);
 
     handleMatrixDisplayFormatComboBox(0);
+    handleMatrixStorageOrderComboBox(0);
 
     variableNameLineEdit->enableReturnPressedOnClear();
 
@@ -59,6 +61,7 @@ SeerMatrixVisualizerWidget::SeerMatrixVisualizerWidget (QWidget* parent) : QWidg
     QObject::connect(matrixStrideLineEdit,          &SeerHistoryLineEdit::returnPressed,                       this,            &SeerMatrixVisualizerWidget::handleRefreshButton);
     QObject::connect(matrixStrideLineEdit,          &SeerHistoryLineEdit::editingFinished,                     this,            &SeerMatrixVisualizerWidget::handleElementStrideLineEdit);
     QObject::connect(matrixDisplayFormatComboBox,   QOverload<int>::of(&QComboBox::currentIndexChanged),       this,            &SeerMatrixVisualizerWidget::handleMatrixDisplayFormatComboBox);
+    QObject::connect(matrixStorageOrderComboBox,    QOverload<int>::of(&QComboBox::currentIndexChanged),       this,            &SeerMatrixVisualizerWidget::handleMatrixStorageOrderComboBox);
     QObject::connect(matrixTableWidget,             &SeerMatrixWidget::dataChanged,                            this,            &SeerMatrixVisualizerWidget::handleDataChanged);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 3)
     QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,                          this,            &SeerMatrixVisualizerWidget::handleThemeChanged);
@@ -561,6 +564,16 @@ void SeerMatrixVisualizerWidget::handleMatrixDisplayFormatComboBox (int index) {
     }
 
     handleRefreshButton();
+}
+
+void SeerMatrixVisualizerWidget::handleMatrixStorageOrderComboBox (int index) {
+
+    // Same bytes, only the cell mapping changes, so no memory re-read is needed.
+    if (index == 1) {
+        matrixTableWidget->setStorageOrder(SeerMatrixWidget::ColumnMajor);
+    }else{
+        matrixTableWidget->setStorageOrder(SeerMatrixWidget::RowMajor);
+    }
 }
 
 void SeerMatrixVisualizerWidget::handleDataChanged () {

--- a/src/SeerMatrixVisualizerWidget.h
+++ b/src/SeerMatrixVisualizerWidget.h
@@ -45,6 +45,7 @@ class SeerMatrixVisualizerWidget : public QWidget, protected Ui::SeerMatrixVisua
         void                handleElementOffsetLineEdit             ();
         void                handleElementStrideLineEdit             ();
         void                handleMatrixDisplayFormatComboBox       (int index);
+        void                handleMatrixStorageOrderComboBox        (int index);
         void                handleDataChanged                       ();
         void                handleThemeChanged                      ();
 

--- a/src/SeerMatrixVisualizerWidget.ui
+++ b/src/SeerMatrixVisualizerWidget.ui
@@ -160,6 +160,23 @@
       </widget>
      </item>
      <item>
+      <widget class="QComboBox" name="matrixStorageOrderComboBox">
+       <property name="toolTip">
+        <string>How the 2D matrix is laid out in memory: row-major (row by row) or column-major (column by column).</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>row-major (C, NumPy)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>column-major (Fortran, Eigen)</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
       <widget class="QToolButton" name="refreshToolButton">
        <property name="toolTip">
         <string>Refresh the display.</string>
@@ -458,6 +475,7 @@
   <tabstop>matrixOffsetLineEdit</tabstop>
   <tabstop>matrixStrideLineEdit</tabstop>
   <tabstop>matrixDisplayFormatComboBox</tabstop>
+  <tabstop>matrixStorageOrderComboBox</tabstop>
   <tabstop>refreshToolButton</tabstop>
   <tabstop>helpToolButton</tabstop>
   <tabstop>matrixTableWidget</tabstop>

--- a/src/SeerMatrixWidget.cpp
+++ b/src/SeerMatrixWidget.cpp
@@ -25,6 +25,7 @@ SeerMatrixWidget::SeerMatrixWidget(QWidget* parent) : QTableWidget(parent) {
     _dataRows       = 0;
     _dataColumns    = 0;
     _dataType       = SeerMatrixWidget::UnknownMatrixType;
+    _storageOrder   = SeerMatrixWidget::RowMajor;
     _addressOffset  = 0;
     _addressStride  = 1;
 
@@ -133,6 +134,18 @@ void SeerMatrixWidget::setDataType (SeerMatrixWidget::MatrixType dataType) {
 
 SeerMatrixWidget::MatrixType SeerMatrixWidget::dataType () const {
     return _dataType;
+}
+
+void SeerMatrixWidget::setStorageOrder (SeerMatrixWidget::StorageOrder order) {
+
+    _storageOrder = order;
+
+    // This repaints the widget with the new storage order.
+    create();
+}
+
+SeerMatrixWidget::StorageOrder SeerMatrixWidget::storageOrder () const {
+    return _storageOrder;
 }
 
 QString SeerMatrixWidget::dataTypeString () const {
@@ -315,10 +328,20 @@ void SeerMatrixWidget::create () {
 
             _dataValues.push_back(val);
 
-            col++;
-            if (col == dataColumns()) {
-                col = 0;
+            // Advance to the next cell. Row-major fills a row at a time;
+            // column-major fills a column at a time (eg: Fortran, Eigen).
+            if (storageOrder() == SeerMatrixWidget::ColumnMajor) {
                 row++;
+                if (row == dataRows()) {
+                    row = 0;
+                    col++;
+                }
+            }else{
+                col++;
+                if (col == dataColumns()) {
+                    col = 0;
+                    row++;
+                }
             }
         }
     }

--- a/src/SeerMatrixWidget.h
+++ b/src/SeerMatrixWidget.h
@@ -41,6 +41,11 @@ class SeerMatrixWidget: public QTableWidget {
             Float64MatrixType    = 8
         };
 
+        enum StorageOrder {
+            RowMajor             = 0,
+            ColumnMajor          = 1
+        };
+
         SeerMatrixWidget(QWidget* parent = 0);
        ~SeerMatrixWidget();
 
@@ -53,6 +58,8 @@ class SeerMatrixWidget: public QTableWidget {
 
         void                            setDataType             (SeerMatrixWidget::MatrixType dataType);
         SeerMatrixWidget::MatrixType    dataType                () const;
+        void                            setStorageOrder         (SeerMatrixWidget::StorageOrder order);
+        SeerMatrixWidget::StorageOrder  storageOrder            () const;
         QString                         dataTypeString          () const;
         const QVector<double>&          dataValues              () const;
         int                             dataRows                () const;
@@ -78,6 +85,7 @@ class SeerMatrixWidget: public QTableWidget {
         int                             _dataRows;
         int                             _dataColumns;
         SeerMatrixWidget::MatrixType    _dataType;
+        SeerMatrixWidget::StorageOrder  _storageOrder;
         QVector<double>                 _dataValues;
 };
 


### PR DESCRIPTION
### Problem

The Matrix Visualizer assumes the matrix is stored row-major (C order). Many
scientific libraries store matrices column-major — Fortran, Eigen (its
default), LAPACK, Julia, MATLAB, R. For those, the visualizer fills the cells
in the wrong order: a square matrix shows up transposed, a non-square one
shows up completely rewrapped, with rows mixing values from different actual
rows. The workaround today is to swap the rows/columns fields, which yields a
clean transpose — readable, but flipped, and it means describing the matrix
to the tool with the wrong dimensions.

### Fix

Add a storage order combo box next to the display format one:

- `row-major (C, NumPy)` — the default, identical to today's behavior,
- `column-major (Fortran, Eigen)` — fills the table a column at a time.

Implementation: a `StorageOrder` enum plus `setStorageOrder()`/
`storageOrder()` on `SeerMatrixWidget`, and the cell-advance in `create()`
walks column-first when column-major is selected. Switching the combo only
remaps the already-fetched bytes to cells — no memory re-read.

I picked the wording "(C, NumPy)" / "(Fortran, Eigen)" so users can recognize
their case without knowing the row/column-major jargon — happy to change the
labels or the combo placement if you prefer something else.

### Testing

Qt 6.4.2, Linux Mint. Debugged a small Eigen 3.4 program (`MatrixXd`, which
is column-major) pointing the visualizer at the matrix data:

- column-major selected: the matrix displays exactly as Eigen prints it,
<img width="1301" height="620" alt="Capture d’écran du 2026-07-25 20-40-51" src="https://github.com/user-attachments/assets/42369dd9-2629-495c-abe6-44b9c6afea09" />
- row-major (default): unchanged behavior, verified on a plain C 2D array,
<img width="1301" height="620" alt="Capture d’écran du 2026-07-25 20-40-38" src="https://github.com/user-attachments/assets/704d8592-d56a-45b1-b096-c635dd82f439" />
- switching the combo back and forth remaps instantly, no re-read,
- a vector (1×N / N×1) is unaffected by the setting, as expected,
- tab order follows the visual order of the controls.
