### PR TITLE
Auto-refresh the Matrix Visualizer at each stopping point

### DIFF
--- a/src/SeerMatrixVisualizerWidget.cpp
+++ b/src/SeerMatrixVisualizerWidget.cpp
@@ -417,6 +417,13 @@ void SeerMatrixVisualizerWidget::handleText (const QString& text) {
             matrixStrideLineEdit->setFocus();
         }
 
+    // At a stopping point, refresh.
+    }else if (text.startsWith("*stopped,reason=\"")) {
+
+        if (autoRefreshCheckBox->isChecked()) {
+            handleRefreshButton();
+        }
+
     }else{
         // Ignore anything else.
     }

--- a/src/SeerMatrixVisualizerWidget.ui
+++ b/src/SeerMatrixVisualizerWidget.ui
@@ -177,6 +177,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="autoRefreshCheckBox">
+       <property name="toolTip">
+        <string>Automatically refresh after each stopping point.</string>
+       </property>
+       <property name="text">
+        <string>Auto</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QToolButton" name="refreshToolButton">
        <property name="toolTip">
         <string>Refresh the display.</string>
@@ -476,6 +486,7 @@
   <tabstop>matrixStrideLineEdit</tabstop>
   <tabstop>matrixDisplayFormatComboBox</tabstop>
   <tabstop>matrixStorageOrderComboBox</tabstop>
+  <tabstop>autoRefreshCheckBox</tabstop>
   <tabstop>refreshToolButton</tabstop>
   <tabstop>helpToolButton</tabstop>
   <tabstop>matrixTableWidget</tabstop>


### PR DESCRIPTION
### Problem

While working on #494 I noticed that the Matrix Visualizer never updates on
its own while stepping: after each step/continue the table keeps showing the
old values, and you have to click the refresh button to see the current ones.

The Struct, Memory and Var visualizers all handle this: they have an "Auto"
checkbox and react to `*stopped` by refreshing. The Matrix Visualizer's
`handleText()` has no `*stopped` branch at all.

### Fix

Same mechanism as the other visualizers: an "Auto" checkbox next to the
refresh button, and a `*stopped,reason=` branch in `handleText()` that calls
`handleRefreshButton()` when the box is checked. 18 lines, no behavior change
when the box is unchecked.

(You may have spotted this checkbox in the #494 screenshots already — those
were taken on my local build, which carried both changes. This PR is that
second change.)

### One open question

I defaulted the checkbox to unchecked, to match Struct/Memory/Var. Personally
I lean toward checked — a debugger view feels like it should track execution,
and that's what surprised me in the first place. The caveat is cost: checked
means a memory re-read and a table rebuild at every stop, which could get
heavy on very large matrices. I kept unchecked for consistency, but happy to
flip the default if you prefer.

### Testing

Qt 6.4.2, Linux Mint, on top of current main (includes #494). Stepping
through an Eigen program with the visualizer open:
<img width="1907" height="1070" alt="Capture d’écran du 2026-07-27 11-51-52" src="https://github.com/user-attachments/assets/844a709a-2ba6-4912-a7fa-48d86ef72827" />
- box checked: the table updates at every breakpoint/step, in both row-major
  and column-major modes,
<img width="1910" height="1072" alt="Capture d’écran du 2026-07-27 11-52-59" src="https://github.com/user-attachments/assets/6bb537e3-b238-4050-8776-af5b3d4740b2" />
- box unchecked: exactly the old behavior (manual refresh only),
<img width="1907" height="1072" alt="Capture d’écran du 2026-07-27 11-52-22" src="https://github.com/user-attachments/assets/e0749095-b3eb-4f2c-8d24-5f4c90a80454" />
- tab order follows the visual order of the controls.

The Array Visualizer has the same gap (no `*stopped` handling); if this
approach looks good to you I can send the same fix for it.
