### PR TITLE
Auto-refresh the Array Visualizer at each stopping point

### DIFF
--- a/src/SeerArrayVisualizerWidget.cpp
+++ b/src/SeerArrayVisualizerWidget.cpp
@@ -705,6 +705,14 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
             bArrayStrideLineEdit->setFocus();
         }
 
+    // At a stopping point, refresh.
+    }else if (text.startsWith("*stopped,reason=\"")) {
+
+        if (autoRefreshCheckBox->isChecked()) {
+            handleaRefreshButton();
+            handlebRefreshButton();
+        }
+
     }else{
         // Ignore anything else.
     }

--- a/src/SeerArrayVisualizerWidget.ui
+++ b/src/SeerArrayVisualizerWidget.ui
@@ -285,6 +285,16 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="8" rowspan="2">
+      <widget class="QCheckBox" name="autoRefreshCheckBox">
+       <property name="toolTip">
+        <string>Automatically refresh after each stopping point.</string>
+       </property>
+       <property name="text">
+        <string>Auto</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="SeerHistoryLineEdit" name="aVariableNameLineEdit">
        <property name="toolTip">
@@ -528,6 +538,7 @@
   <tabstop>aArrayStrideLineEdit</tabstop>
   <tabstop>aArrayDisplayFormatComboBox</tabstop>
   <tabstop>aRefreshToolButton</tabstop>
+  <tabstop>autoRefreshCheckBox</tabstop>
   <tabstop>bAxisComboBox</tabstop>
   <tabstop>bVariableNameLineEdit</tabstop>
   <tabstop>bVariableAddressLineEdit</tabstop>


### PR DESCRIPTION
### What

Follow-up to #496, as offered there: the Array Visualizer had the same gap
as the Matrix one — no `*stopped` handling, so the table and the chart keep
showing stale values while stepping until you click refresh.

Same mechanism, adapted to this widget's two-array layout: a single "Auto"
checkbox (spanning the A and B rows, next to their refresh buttons), and a
`*stopped,reason=` branch in `handleText()` that triggers both refresh
handlers. Each handler already returns early when its variable is not set,
so with only one array configured just that one is re-read.

A nice side effect: in X/Y scatter mode (array A against array B), a stop
refreshes both arrays at once — the phase-portrait usage from #481/#485
updates as you step.

Unchecked by default, per the convention confirmed in #496. 19 lines.

### Testing

<img width="1672" height="873" alt="image" src="https://github.com/user-attachments/assets/2801180f-d3af-48a0-8630-380a234480ed" />

Qt 6.4.2, Linux Mint. Stepping through a 4000-point damped-oscillator
program with the visualizer open:

- box checked, single array: table and chart update at every stop,
- box checked, X/Y scatter (A vs B): both arrays re-read, the phase
  portrait redraws at every stop,
- box unchecked: exactly the old behavior,
- tab order follows the visual order of the controls.

One heads-up: auto-refresh makes the rendering cost of scatter mode more
visible, since it now redraws at every stop. I've been working on a
performance improvement for exactly that (scatter redraws are currently much
more expensive than line/spline ones) — I'll propose it as a separate PR
soon.