### PR TITLE
Fix string and class-name syntax highlighting rules

### DIFF
--- a/src/SeerAdaSourceHighlighter.cpp
+++ b/src/SeerAdaSourceHighlighter.cpp
@@ -55,7 +55,7 @@ void SeerAdaSourceHighlighter::setHighlighterSettings(const SeerHighlighterSetti
 
     // Set class format and expression.
     // (Ada typically doesn't have a distinguished class case convention, but we can reuse uppercase Start)
-    rule.pattern = QRegularExpression(QStringLiteral("\\b[A-Z][A-z0-9_]*\\b"));
+    rule.pattern = QRegularExpression(QStringLiteral("\\b[A-Z][A-Za-z0-9_]*\\b"));
     rule.format  = _classFormat;
     _highlightingRules.append(rule);
 
@@ -74,7 +74,7 @@ void SeerAdaSourceHighlighter::setHighlighterSettings(const SeerHighlighterSetti
     }
 
     // Set quote format and expression.
-    rule.pattern = QRegularExpression(QStringLiteral("\".*\""));
+    rule.pattern = QRegularExpression(QStringLiteral("\"[^\"]*\""));
     rule.format  = _quotationFormat;
     _highlightingRules.append(rule);
 

--- a/src/SeerCppSourceHighlighter.cpp
+++ b/src/SeerCppSourceHighlighter.cpp
@@ -79,11 +79,6 @@ void SeerCppSourceHighlighter::setHighlighterSettings (const SeerHighlighterSett
     rule.format = _classFormat;
     _highlightingRules.append(rule);
 
-    // Set quote format and expression.
-    rule.pattern = QRegularExpression(QStringLiteral("\".*\""));
-    rule.format = _quotationFormat;
-    _highlightingRules.append(rule);
-
     // Set function format and expression.
     rule.pattern = QRegularExpression(QStringLiteral("\\b[A-Za-z0-9_]+(?=\\s*\\()"));
     rule.format = _functionFormat;
@@ -95,6 +90,13 @@ void SeerCppSourceHighlighter::setHighlighterSettings (const SeerHighlighterSett
         rule.format  = _keywordFormat;
         _highlightingRules.append(rule);
     }
+
+    // Set quote format and expression. This rule must come after the function
+    // and keyword rules so that string contents keep the quote format (same
+    // order as the Ada highlighter).
+    rule.pattern = QRegularExpression(QStringLiteral("\"[^\"]*\""));
+    rule.format = _quotationFormat;
+    _highlightingRules.append(rule);
 
     // Set single line comment format and expression.
     rule.pattern = QRegularExpression(QStringLiteral("//[^\n]*"));

--- a/src/SeerOdinSourceHighlighter.cpp
+++ b/src/SeerOdinSourceHighlighter.cpp
@@ -67,11 +67,6 @@ void SeerOdinSourceHighlighter::setHighlighterSettings (const SeerHighlighterSet
     rule.format  = _classFormat;
     _highlightingRules.append(rule);
 
-    // Set quote format and expression.
-    rule.pattern = QRegularExpression(QStringLiteral("\".*\""));
-    rule.format  = _quotationFormat;
-    _highlightingRules.append(rule);
-
     // Set function format and expression.
     rule.pattern = QRegularExpression(QStringLiteral("\\b[A-Za-z0-9_]+(?=\\s*\\()"));
     rule.format  = _functionFormat;
@@ -83,6 +78,13 @@ void SeerOdinSourceHighlighter::setHighlighterSettings (const SeerHighlighterSet
         rule.format  = _keywordFormat;
         _highlightingRules.append(rule);
     }
+
+    // Set quote format and expression. This rule must come after the function
+    // and keyword rules so that string contents keep the quote format (same
+    // order as the Ada highlighter).
+    rule.pattern = QRegularExpression(QStringLiteral("\"[^\"]*\""));
+    rule.format  = _quotationFormat;
+    _highlightingRules.append(rule);
 
     // Set single line comment format and expression.
     rule.pattern = QRegularExpression(QStringLiteral("//[^\n]*"));

--- a/src/SeerRustSourceHighlighter.cpp
+++ b/src/SeerRustSourceHighlighter.cpp
@@ -57,13 +57,8 @@ void SeerRustSourceHighlighter::setHighlighterSettings(const SeerHighlighterSett
     HighlightingRule rule;
 
     // Set class format and expression.
-    rule.pattern = QRegularExpression(QStringLiteral("\\b[A-Z][A-z0-9_]*\\b"));
+    rule.pattern = QRegularExpression(QStringLiteral("\\b[A-Z][A-Za-z0-9_]*\\b"));
     rule.format  = _classFormat;
-    _highlightingRules.append(rule);
-
-    // Set quote format and expression.
-    rule.pattern = QRegularExpression(QStringLiteral("\".*\""));
-    rule.format  = _quotationFormat;
     _highlightingRules.append(rule);
 
     // Set function format and expression.
@@ -77,6 +72,13 @@ void SeerRustSourceHighlighter::setHighlighterSettings(const SeerHighlighterSett
         rule.format  = _keywordFormat;
         _highlightingRules.append(rule);
     }
+
+    // Set quote format and expression. This rule must come after the function
+    // and keyword rules so that string contents keep the quote format (same
+    // order as the Ada highlighter).
+    rule.pattern = QRegularExpression(QStringLiteral("\"[^\"]*\""));
+    rule.format  = _quotationFormat;
+    _highlightingRules.append(rule);
 
     // Set single line comment format and expression.
     rule.pattern = QRegularExpression(QStringLiteral("//[^\n]*"));


### PR DESCRIPTION
### Problem

I noticed that inside a string literal, anything that looks like a function
call gets re-colored with the function format. For example in the editor:

```cpp
std::cout << "Buffers prets : rgba/rgb (" << W << "x" << H << ")\n";
```

`rgb` shows up in the function color (it is followed by ` (`) while the rest
of the string is in the quotation color. The same happens with keywords
inside strings (`"delete this"` colors `delete` as a keyword).

### Cause and fix

`QSyntaxHighlighter` applies the highlighting rules in order, and a later
rule overwrites the format of an earlier one where they overlap. In the C++,
Rust and Odin highlighters the quotation rule runs *before* the function and
keyword rules, so those re-color parts of the string. The Ada highlighter
already has the right order — quotation after functions and keywords.

This PR aligns C++, Rust and Odin on the Ada order, and fixes two small
regex issues in the same rule sets:

- the quotation pattern `".*"` was greedy: with two strings on one line
  (`"a" + "b"`) everything from the first quote to the last was colored as
  one string. Now `"[^"]*"`.
- the class-name pattern in the Rust and Ada highlighters used `[A-z]`,
  which accidentally includes the ASCII characters between `Z` and `a`
  (`[ \ ] ^ _` and backtick). Now `[A-Za-z]`.

Comments keep the last word over strings, unchanged: `// "text"` still
colors as a comment.

### Testing

Qt 6.4.2, Linux Mint. Opened C++, Rust and Odin sources in the editor and checked:

- strings containing `name (`, keywords, or two strings on one line now
  render entirely in the quotation color,
- functions, keywords, class names and comments outside strings unchanged,
- `// comment with "quotes"` still renders entirely as a comment (no regression). 

**C++:**
<img width="2560" height="1400" alt="Capture d’écran du 2026-07-29 12-40-58" src="https://github.com/user-attachments/assets/134a63af-bdb3-4ac1-b4c8-1fd8207da691" />
<img width="2560" height="1400" alt="Capture d’écran du 2026-07-29 12-41-36" src="https://github.com/user-attachments/assets/b31673f8-7d45-49a5-90b5-a7caade056d1" />


**Rust:**
<img width="2560" height="1400" alt="Capture d’écran du 2026-07-29 11-57-12" src="https://github.com/user-attachments/assets/7b063bf6-b11d-419b-8554-87a2a2395c7b" />
<img width="2560" height="1400" alt="Capture d’écran du 2026-07-29 11-57-52" src="https://github.com/user-attachments/assets/d4299a16-100c-401f-acf1-acfe4115a53a" />

**Odin:**
<img width="2560" height="1400" alt="Capture d’écran du 2026-07-29 12-27-40" src="https://github.com/user-attachments/assets/8b41ec2a-0256-4ba9-b054-4b775cb419e8" />
<img width="2560" height="1400" alt="Capture d’écran du 2026-07-29 12-28-24" src="https://github.com/user-attachments/assets/a548bbba-d6ca-4262-923d-506fed2e9ebf" />


