### PR TITLE
perf: speed up the Array Visualizer scatter phase-portrait

### DIFF
--- a/src/SeerArrayVisualizerWidget.cpp
+++ b/src/SeerArrayVisualizerWidget.cpp
@@ -28,11 +28,18 @@
 // Qt Charts 6.x workaround: scatter marker items can be (re)created without
 // inheriting the series' pen/brush, leaving near-invisible ~1px markers.
 // Small arrays usually render fine; large ones (e.g. 4000 points) reliably
-// degrade. The series-level state is correct in both cases (verified with an
-// instrumented build), so the style is lost at the marker-item level inside
-// Qt Charts. Because the series setters are guarded (a call with an unchanged
-// value is a no-op), we force two *actual* value transitions so the style is
-// pushed down to the marker items unconditionally.
+// degrade. The series-level state is correct in both cases, so the style is
+// lost at the marker-item level inside Qt Charts. Re-applying the pen/brush
+// after the series is added pushes the style down to the marker items.
+//
+// Two passes suffice, not four. This runs after addSeries(), so the series
+// already carries the chart theme's pen/brush; setPen(NoPen) and setBrush()
+// are therefore real value transitions (no built-in Qt theme uses NoPen for
+// a scatter pen nor this exact colour for the brush) and are not swallowed
+// by the guarded setters. Even if one were a no-op, the other setter's
+// update re-pushes both pen and brush to every marker item. Two passes over
+// the (up to thousands of) marker items instead of four roughly halves this
+// step's cost, with no visible change to the markers.
 //
 static void redecorateScatterSeries (QXYSeries* series) {
 
@@ -42,8 +49,6 @@ static void redecorateScatterSeries (QXYSeries* series) {
         return;
     }
 
-    scatter->setPen(QPen(Qt::transparent));
-    scatter->setBrush(QBrush(Qt::transparent));
     scatter->setPen(QPen(Qt::NoPen));
     scatter->setBrush(QBrush(QColor(31, 119, 180)));
 }
@@ -164,6 +169,10 @@ void SeerArrayVisualizerWidget::setAVariableName (const QString& name) {
         return;
     }
 
+    // Coalesce this variable's setup (address reset + data/offset/stride) into
+    // a single table rebuild; the guard flushes it when it leaves scope.
+    SeerArrayWidget::BulkUpdate bulk(arrayTableWidget);
+
     setAVariableAddress("");
 
     // Clear old contents.
@@ -281,6 +290,10 @@ void SeerArrayVisualizerWidget::setBVariableName (const QString& name) {
 
         return;
     }
+
+    // Coalesce this variable's setup (address reset + data/offset/stride) into
+    // a single table rebuild; the guard flushes it when it leaves scope.
+    SeerArrayWidget::BulkUpdate bulk(arrayTableWidget);
 
     setBVariableAddress("");
 
@@ -540,6 +553,8 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
 
                 // Give the byte array to the hex widget.
                 bool ok;
+                SeerArrayWidget::BulkUpdate bulk(arrayTableWidget);
+
                 arrayTableWidget->setAData(arrayTableWidget->aLabel(), new SeerArrayWidget::DataStorageArray(array));
 
                 if (aArrayOffsetLineEdit->text() != "") {
@@ -587,6 +602,8 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
 
                 // Give the byte array to the hex widget.
                 bool ok;
+                SeerArrayWidget::BulkUpdate bulk(arrayTableWidget);
+
                 arrayTableWidget->setBData(arrayTableWidget->bLabel(), new SeerArrayWidget::DataStorageArray(array));
 
                 if (bArrayOffsetLineEdit->text() != "") {

--- a/src/SeerArrayWidget.cpp
+++ b/src/SeerArrayWidget.cpp
@@ -33,6 +33,9 @@ SeerArrayWidget::SeerArrayWidget(QWidget* parent) : QTableWidget(parent) {
     _bAddressOffset  = 0;
     _bAddressStride  = 1;
 
+    _bulkUpdateDepth = 0;
+    _createPending   = false;
+
     setAAddressOffset(0);
     setAAddressStride(1);
 
@@ -314,6 +317,14 @@ void SeerArrayWidget::setBData(const QString& label, SeerArrayWidget::DataStorag
 
 void SeerArrayWidget::create () {
 
+    // Coalesce a burst of property changes: while a bulk update is active,
+    // defer the (expensive) table rebuild and just record that one is pending.
+    // endBulkUpdate() performs the single rebuild once the burst is complete.
+    if (_bulkUpdateDepth > 0) {
+        _createPending = true;
+        return;
+    }
+
     // Clear the table. We're going to recreate it.
     clear();
     setRowCount(0);
@@ -582,6 +593,32 @@ void SeerArrayWidget::create () {
     }
 
     emit dataChanged();
+}
+
+void SeerArrayWidget::beginBulkUpdate () {
+
+    _bulkUpdateDepth++;
+}
+
+void SeerArrayWidget::endBulkUpdate () {
+
+    if (_bulkUpdateDepth > 0) {
+        _bulkUpdateDepth--;
+    }
+
+    // Once fully unwound, do the single deferred rebuild (if any setter fired).
+    if (_bulkUpdateDepth == 0 && _createPending) {
+        _createPending = false;
+        create();
+    }
+}
+
+SeerArrayWidget::BulkUpdate::BulkUpdate (SeerArrayWidget* widget) : _widget(widget) {
+    _widget->beginBulkUpdate();
+}
+
+SeerArrayWidget::BulkUpdate::~BulkUpdate () {
+    _widget->endBulkUpdate();
 }
 
 SeerArrayWidget::DataStorageArray::DataStorageArray(const QByteArray& arr) {

--- a/src/SeerArrayWidget.h
+++ b/src/SeerArrayWidget.h
@@ -46,6 +46,21 @@ class SeerArrayWidget: public QTableWidget {
 
         int                         elementsPerLine         () const;
 
+        // RAII guard: coalesces a burst of property changes into a single
+        // rebuild. While a guard is alive create() is deferred; the single
+        // rebuild happens when it goes out of scope. Nesting is supported.
+        // Prefer a guard over the private begin/end pair so the matching end
+        // is guaranteed even on early return or exception.
+        class BulkUpdate {
+            public:
+                explicit BulkUpdate     (SeerArrayWidget* widget);
+                               ~BulkUpdate ();
+                                BulkUpdate (const BulkUpdate&) = delete;
+                BulkUpdate&     operator= (const BulkUpdate&) = delete;
+            private:
+                SeerArrayWidget*        _widget;
+        };
+
         const QString&              aAxis                   () const;
         void                        setAAxis                (const QString& axis);
         const QString&              aLabel                  () const;
@@ -88,6 +103,11 @@ class SeerArrayWidget: public QTableWidget {
 
     private:
         void                        create                  ();
+        void                        beginBulkUpdate         ();
+        void                        endBulkUpdate           ();
+
+        int                         _bulkUpdateDepth;
+        bool                        _createPending;
 
         QString                     _aAxis;
         QString                     _aLabel;

--- a/tests/helloscatter/Makefile
+++ b/tests/helloscatter/Makefile
@@ -1,0 +1,20 @@
+# This is the default target, which will be built when
+# you invoke make
+.PHONY: all
+all: helloscatter
+
+# This rule tells make how to build helloscatter from helloscatter.cpp
+helloscatter: helloscatter.cpp
+	g++ -g -o helloscatter helloscatter.cpp
+
+# This rule tells make to copy helloscatter to the binaries subdirectory,
+# creating it if necessary
+.PHONY: install
+install:
+	mkdir -p binaries
+	cp -p helloscatter binaries
+
+# This rule tells make to delete helloscatter
+.PHONY: clean
+clean:
+	rm -f helloscatter helloscatter.o

--- a/tests/helloscatter/helloscatter.cpp
+++ b/tests/helloscatter/helloscatter.cpp
@@ -1,0 +1,49 @@
+#include <cstdio>
+
+#define NPOINTS 4000
+
+double pos[NPOINTS];
+double vel[NPOINTS];
+
+//
+// Fill pos/vel with the trajectory of a damped harmonic oscillator
+// (semi-implicit Euler integration).
+//
+void integrate (double damping) {
+
+    double x  = 1.0;
+    double v  = 0.0;
+    double w  = 1.0;
+    double dt = 0.005;
+
+    for (int i=0; i<NPOINTS; i++) {
+        v += (-w*w*x - damping*v) * dt;
+        x += v * dt;
+
+        pos[i] = x;
+        vel[i] = v;
+    }
+}
+
+//
+// Exercises the Array Visualizer with a large two-array scatter plot.
+//
+// Open the Array Visualizer, enter 'pos' as array A and 'vel' as array B,
+// length 4000, select B's axis as 'Y', scatter mode, and check 'Auto'.
+// Then set a breakpoint on the printf below and 'Continue' a few times:
+// each stop recomputes the trajectory with a different damping and
+// refreshes the 4000-point phase portrait.
+//
+int main (void) {
+
+    for (int run=0; run<10; run++) {
+
+        double damping = 0.05 + 0.05*run;
+
+        integrate(damping);
+
+        printf("run %d: damping=%.2f  pos[end]=%f\n", run, damping, pos[NPOINTS-1]);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Problem

Plotting one array against another in scatter mode — e.g. a phase portrait
(X = array A, Y = array B) of a few thousand points — is noticeably janky:
every refresh, and every step while the visualizer is open, freezes the UI
for the best part of a second. Line/spline modes and small arrays feel fine.

This is the follow-up I mentioned in #498: now that the Auto checkbox
refreshes both arrays at every stop, this cost is paid automatically on
each stop while the visualizer is open, not only on a manual refresh —
which makes it worth fixing.

### Analysis

Profiling a single user refresh on a 4000-point, two-array scatter (Qt
Charts 6.4.2), with per-phase timing, showed two compounding costs — both
proportional to the marker count, both absent in line/spline mode:

**1. Redundant rebuilds.** `handleText()`, `setAVariableName()` and
`setBVariableName()` set the address, data, offset and stride in sequence.
Every one of those setters calls `SeerArrayWidget::create()`, which rebuilds
the whole table *and* emits `dataChanged()` → a full chart rebuild. A single
refresh therefore triggered ~3 rebuilds per array.

**2. Over-decoration.** For each rebuild, `handleDataChanged()` broke down
(scatter, 4000 pts) roughly as:

| step | cost |
|------|------|
| `addSeries()` (Qt builds 4000 marker items) | ~100 ms |
| `redecorateScatterSeries()` — 4 style passes over the markers | ~113 ms |
| `handlePointsCheckBox()` — 1 visibility pass over the markers | ~49 ms |
| table fill, axes, zoom | < 10 ms |
| **total per rebuild** | **~260 ms** |

By contrast the same rebuild in line mode is ~3 ms. The table fill itself
(`SeerArrayWidget::create()`) is ~8 ms and not the bottleneck.

So one refresh ≈ 3 rebuilds × ~260 ms ≈ **~800 ms**, dominated by repeated
full passes over the scatter marker items.

### Fix

**1. Coalesce the rebuilds.** Add a `SeerArrayWidget::BulkUpdate` RAII guard
that defers `create()` while it is alive and performs a single rebuild when
it leaves scope; wrap each setter burst with one. ~3 rebuilds/array → 1. An
RAII guard (rather than a manual begin/end pair) so the deferred rebuild is
always flushed, even on an early return or exception.

**2. Halve the restyle.** `redecorateScatterSeries()` applied four style
passes (transparent pen/brush, then the final pen/brush). Two suffice: it
runs after `addSeries()`, so the series carries the chart theme's pen/brush;
`setPen(NoPen)`/`setBrush(<color>)` are therefore real value transitions (no
built-in Qt theme uses those exact values) that the guarded setters keep,
and either setter's update re-pushes both pen and brush to the markers. No
visible change to the markers (verified — see Testing).

### Result

On the 4000-point two-array scatter, one refresh dropped from **~800 ms to
~200 ms**. Line/spline modes were already cheap and are unaffected.

### Testing

The PR includes `tests/helloscatter`, a repro program in the style of the
existing tests: a damped-oscillator phase portrait (`pos` vs `vel`, 4000
points) with a breakpoint loop that recomputes the trajectory at each stop,
so the refresh cost is easy to feel with the Auto checkbox on — before and
after this change.

Qt 6.4.2, Linux Mint. Verified with it:
- markers still render styled (no regression of #485),
- the plot updates correctly on refresh and when stopping at different
  breakpoints, across scatter / line / spline,
- the variable address field still populates,
- rebased on current main: the #498 auto-refresh path goes through the
  same coalesced rebuild (one rebuild per array per stop).

### Two rough edges noticed while stress-testing (unrelated to this change)

Reporting them here for transparency — I'm trying to polish this corner
of Seer and plan to follow up on both:

1. With Auto checked, when the program *exits* the visualizer still tries
   to refresh (the `*stopped` event with `reason="exited-normally"` is not
   filtered) and logs "unable to read memory". Small fix, I'll propose it
   as a separate PR shortly.
2. Rapid-firing Continue can land a refresh while the program is already
   running again ("Cannot execute this command while the selected thread
   is running"). This one looks deeper (the refresh commands race with the
   resume); I'd rather investigate it properly before proposing anything.