### PR TITLE
fix: matrix visualizer min-max value loss

### DIFF
--- a/src/SeerMatrixVisualizerWidget.cpp
+++ b/src/SeerMatrixVisualizerWidget.cpp
@@ -618,8 +618,8 @@ void SeerMatrixVisualizerWidget::handleDataChanged () {
 
     // Calculate statistics.
     double val  = 0.0;
-    double min  = 0.0;
-    double max  = 0.0;
+    double min  = values[0];
+    double max  = values[0];
     double sum  = 0.0;
     double sum2 = 0.0;
     double avg  = 0.0;


### PR DESCRIPTION
In the `void SeerMatrixVisualizerWidget::handleDataChanged()` method, the statistical data is initialized with 0. One reason for this is that, for positive arrays only, the minimum value in the array can never be smaller than 0.0 (the value passed to the `std::min` method), and similarly, for completely negative arrays, the value passed to the `std::max` method can never be greater than 0.0.

To test this, I wrote the following driver code:
```
#include <stdlib.h>

int all_positive[4][4];
int all_negative[4][4];
int mixed_sign[4][4];

int main(void) {
    for (int i = 0; i < 4; i++) {
        for (int j = 0; j < 4; j++) {
            all_positive[i][j] = 5 + i * 4 + j;
            all_negative[i][j] = -5 - (i * 4 + j);
            mixed_sign[i][j]   = (i * 4 + j) - 8;
        }
    }

    return EXIT_SUCCESS;
}
```
Output:
<img width="959" height="1050" alt="all_neg" src="https://github.com/user-attachments/assets/228947f8-41f2-4e0b-8395-5adbe96569bc" />
<img width="961" height="1050" alt="all_positive" src="https://github.com/user-attachments/assets/2483a53e-c8a9-446c-b016-9066369c73a5" />

To fix this, I initialized the values ​​with the first elements of the array, so that larger or smaller values ​​can override each other if they exist within the array. I didn't add any protection because the presence of data was already checked above in the block.