### PR TITLE
Let feature gdbLiveWatch handles GotoDefinition

### DIFF
--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -1910,7 +1910,13 @@ void SeerGdbWidget::handleGdbExecutableFunctions (int id, const QString& functio
     }
 
     QApplication::setOverrideCursor(Qt::BusyCursor);
-    handleGdbCommand(QString("%1-symbol-info-functions --include-nondebug --name %2").arg(id).arg(functionRegex));
+    
+    // If openocd is running, then let _gdbLiveWatchProcess handles it
+    if (executableLaunchMode() == "openocd") {
+        _openocdWidget->gdbLiveWatchRunCommand(QString("%1-symbol-info-functions --include-nondebug --name %2").arg(id).arg(functionRegex));
+    }
+    else
+        handleGdbCommand(QString("%1-symbol-info-functions --include-nondebug --name %2").arg(id).arg(functionRegex));
     QApplication::restoreOverrideCursor();
 }
 
@@ -4088,7 +4094,8 @@ void SeerGdbWidget::handleGdbMultiarchOpenOCDExecutable ()
     QObject::connect(this,          &SeerGdbWidget::sessionTerminated,  _openocdWidget, &SeerOpenOCDWidget::terminate, Qt::UniqueConnection);
     // Openocd Live watch
     QObject::connect(_gdbMonitor,   &GdbMonitor::caretTextOutput,       _openocdWidget, &SeerOpenOCDWidget::handleText,Qt::UniqueConnection);
-    QObject::connect(_openocdWidget,&SeerOpenOCDWidget::toTracker,      variableManagerWidget->variableTrackerBrowserWidget(),          &SeerVariableTrackerBrowserWidget::handleText,Qt::UniqueConnection);
+    QObject::connect(_openocdWidget,&SeerOpenOCDWidget::toTracker,      variableManagerWidget->variableTrackerBrowserWidget(),          &SeerVariableTrackerBrowserWidget::handleText,  Qt::UniqueConnection);
+    QObject::connect(_openocdWidget,&SeerOpenOCDWidget::toEditor,       editorManagerWidget,                                            &SeerEditorManagerWidget::handleText,           Qt::UniqueConnection);
 
     _openocdWidget->createOpenOCDConsole(commandLogsWidget->logsTabWidgetInstance());
     // Start OpenOCD with the given path and command
@@ -4155,6 +4162,11 @@ void SeerGdbWidget::handleGdbMultiarchOpenOCDExecutable ()
         if (newExecutableFlag() == true) {
             if (executablePreGdbCommands().isEmpty() == false)
                 handleGdbExecutablePreCommands();               // Run any 'pre' commands before program is loaded.
+
+            // Openocd handle gdb pre commands
+            for (const auto& i : _executablePreGdbCommands) {
+                _openocdWidget->gdbLiveWatchRunCommand(i);
+            }
 
             if (gdbServerDebug()) {
                 handleGdbCommand("-gdb-set debug remote 1"); // Turn on gdbserver debug

--- a/src/SeerOpenOCDWidget.cpp
+++ b/src/SeerOpenOCDWidget.cpp
@@ -173,7 +173,7 @@ bool SeerOpenOCDWidget::startGdbLiveWatch (const QString &gdbExe)
         _gdbLiveWatchProcess->start(gdbExe, QStringList() << "-q" << "--interpreter=mi");
     }
     connect(_liveWatchTimer, &QTimer::timeout, [this](){
-        gdbLiveWatchRunCommand("-var-update-live-watch");
+        _gdbLiveWatchProcess->write("-var-update-live-watch");
     });
     _liveWatchTimer->start(500);       // Hard code Refresh rate = 2Hz
     connect(_gdbLiveWatchProcess, &QProcess::readyReadStandardOutput,   this, &SeerOpenOCDWidget::handleGdbOutput);
@@ -194,7 +194,7 @@ void SeerOpenOCDWidget::terminateGdbLiveWatch()
 {
     if (_gdbLiveWatchProcess) {
         _gdbLiveWatchProcess->terminate();
-        _gdbLiveWatchProcess->waitForFinished();
+        // _gdbLiveWatchProcess->waitForFinished();
         delete _gdbLiveWatchProcess;
         _gdbLiveWatchProcess = nullptr;
         _liveWatchTimer->stop();
@@ -210,6 +210,15 @@ void SeerOpenOCDWidget::handleGdbOutput()
         for (const QString& line : output.split('\n', Qt::SkipEmptyParts))
             if (line.contains("^done,value="))
                     emit toTracker(line);
+    }
+    // If output contains symbol of functions, variables, struct -> handle go to definition -> emit to SeerEditorManagerWidget::handleText
+    if (output.contains(QRegularExpression("^([0-9]+)\\^done,symbols="))) {
+        // Format: 4^done,symbols={debug=[{filename="/usr/src/kernel/init/main.c",
+        //                          fullname="/usr/src/kernel/init/main.c",
+        //                          symbols=[{line="887",name="arch_call_rest_init",type="void (void)",
+        //                          description="void arch_call_rest_init(void);"}]}]}
+        
+        emit toEditor(output);
     }
 }
 

--- a/src/SeerOpenOCDWidget.h
+++ b/src/SeerOpenOCDWidget.h
@@ -36,6 +36,7 @@ class SeerOpenOCDWidget: public SeerLogWidget{
     signals:
         void                                openocdStartFailed              ();
         void                                toTracker                       (const QString& text);
+        void                                toEditor                        (const QString& text);
 
     private slots:
         void                                handleReadOutput                ();


### PR DESCRIPTION
As mentioned in #474, GotoDefinition doesn't work during run time with 'main' gdb
The solution is to let _gdbLiveWatchProcess handles it
