### PR TITLE
Don't auto-refresh the Array/Matrix visualizers when the program exits

### DIFF
--- a/src/SeerArrayVisualizerWidget.cpp
+++ b/src/SeerArrayVisualizerWidget.cpp
@@ -722,8 +722,9 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
             bArrayStrideLineEdit->setFocus();
         }
 
-    // At a stopping point, refresh.
-    }else if (text.startsWith("*stopped,reason=\"")) {
+    // At a stopping point, refresh. Skip the "exited" reasons: the program
+    // is gone and reading the arrays would fail with a memory error.
+    }else if (text.startsWith("*stopped,reason=\"") && text.startsWith("*stopped,reason=\"exited") == false) {
 
         if (autoRefreshCheckBox->isChecked()) {
             handleaRefreshButton();

--- a/src/SeerMatrixVisualizerWidget.cpp
+++ b/src/SeerMatrixVisualizerWidget.cpp
@@ -417,8 +417,9 @@ void SeerMatrixVisualizerWidget::handleText (const QString& text) {
             matrixStrideLineEdit->setFocus();
         }
 
-    // At a stopping point, refresh.
-    }else if (text.startsWith("*stopped,reason=\"")) {
+    // At a stopping point, refresh. Skip the "exited" reasons: the program
+    // is gone and reading the matrix would fail with a memory error.
+    }else if (text.startsWith("*stopped,reason=\"") && text.startsWith("*stopped,reason=\"exited") == false) {
 
         if (autoRefreshCheckBox->isChecked()) {
             handleRefreshButton();


### PR DESCRIPTION
### Problem

This is the first of the two rough edges mentioned at the end of #500,
found while stress-testing it.

gdb reports the program's exit as a `*stopped` event
(`*stopped,reason="exited-normally"`, `"exited"` or `"exited-signalled"`).
The Array and Matrix visualizers treat any `*stopped,reason="..."` as a
stopping point, so with the Auto checkbox checked (#496/#498) the exit
triggers one last refresh — memory reads on a process that no longer
exists. The symptom depends on where the array lives:

- heap or stack storage (e.g. a `std::vector`'s data): the pages are gone,
  gdb answers "unable to read memory" and the errors land in the log;
- global storage (like `tests/helloscatter`'s `pos`/`vel`): gdb silently
  serves the read from the executable file instead of the dead process
  (`.bss` → zeros), so the refresh "succeeds" and the plot quietly
  collapses to zeros — no error at all, which is arguably worse.

Deterministic repro: Array Visualizer with Auto checked, Continue until
the program ends. With `tests/helloscatter` the phase portrait collapses
at exit; with any vector-backed array the log fills with memory errors.

### Fix

Skip the `exited-*` reasons in the `*stopped` filter of both visualizers
(the two widgets that have the Auto checkbox). Two one-line guards, one
per widget; normal stops (breakpoints, steps, signals) refresh exactly as
before.

### Testing

Qt 6.4.2, Linux Mint. Setup for the screenshots below: a 4000-point
damped-oscillator phase portrait with vector-backed (heap) arrays, Array
Visualizer on `&pos[0]` / `&vit[0]`, scatter mode, Auto checked, a
breakpoint right after the arrays are filled, then Continue until the
program exits.

1. **Current main, at the breakpoint** — healthy phase portrait.

<img width="2545" height="1393" alt="Capture d’écran du 2026-08-09 20-29-01" src="https://github.com/user-attachments/assets/b10fc6c9-1187-41b4-9ae7-9e76df75b79d" />

2. **Current main, after the program exits** — the auto-refresh fires on
   the dead process and pops "Unable to read memory" errors.
   
<img width="2554" height="1395" alt="Capture d’écran du 2026-08-09 20-29-25" src="https://github.com/user-attachments/assets/85030708-2482-40fa-83c3-72c04d72b91a" />

3. **This branch, after the program exits** — no errors; the plot keeps
   its last valid data.
   
<img width="2545" height="1393" alt="Capture d’écran du 2026-08-09 20-29-01" src="https://github.com/user-attachments/assets/0757e2e2-604f-4917-af09-62cbc8c3ab4d" />


Also verified: breakpoint stops still auto-refresh normally, and with
global arrays (`tests/helloscatter`) the plot no longer collapses to
zeros at exit.
