### PR TITLE
Add a Fortran syntax highlighter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,6 +153,7 @@ set(HEADER_FILES
     SeerWatchpointsBrowserWidget.h
     SeerSourceHighlighter.h
     SeerAdaSourceHighlighter.h
+    SeerFortranSourceHighlighter.h
     SeerCppSourceHighlighter.h
     SeerOdinSourceHighlighter.h
     SeerRustSourceHighlighter.h
@@ -270,6 +271,7 @@ set(SOURCE_FILES
     SeerWatchpointsBrowserWidget.cpp
     SeerSourceHighlighter.cpp
     SeerAdaSourceHighlighter.cpp
+    SeerFortranSourceHighlighter.cpp
     SeerCppSourceHighlighter.cpp
     SeerOdinSourceHighlighter.cpp
     SeerRustSourceHighlighter.cpp

--- a/src/SeerEditorConfigPage.cpp
+++ b/src/SeerEditorConfigPage.cpp
@@ -31,6 +31,7 @@ SeerEditorConfigPage::SeerEditorConfigPage(QWidget* parent) : QWidget(parent) {
     QObject::connect(rustSuffixesLineEdit,        &QHistoryLineEdit::lostFocus,             this, &SeerEditorConfigPage::handleHighlighterChanged);
     QObject::connect(odinSuffixesLineEdit,        &QHistoryLineEdit::lostFocus,             this, &SeerEditorConfigPage::handleHighlighterChanged);
     QObject::connect(adaSuffixesLineEdit,         &QHistoryLineEdit::lostFocus,             this, &SeerEditorConfigPage::handleHighlighterChanged);
+    QObject::connect(fortranSuffixesLineEdit,     &QHistoryLineEdit::lostFocus,             this, &SeerEditorConfigPage::handleHighlighterChanged);
     QObject::connect(languageTabWidget,           &QTabWidget::currentChanged,              this, &SeerEditorConfigPage::handleLanguageTabChanged);
     QObject::connect(themeApplyToolButton,        &QToolButton::clicked,                    this, &SeerEditorConfigPage::handleApplyTheme);
 
@@ -149,6 +150,8 @@ void SeerEditorConfigPage::setHighlighterSettings (const SeerHighlighterSettings
     odinSuffixesLineEdit->setCursorPosition(0);
     adaSuffixesLineEdit->setText(_highlighterSettings.adaSourceSuffixes());
     adaSuffixesLineEdit->setCursorPosition(0);
+    fortranSuffixesLineEdit->setText(_highlighterSettings.fortranSourceSuffixes());
+    fortranSuffixesLineEdit->setCursorPosition(0);
 
     // Update our sample editor.
     editorWidget->sourceArea()->setHighlighterSettings(highlighterSettings());
@@ -333,6 +336,7 @@ void SeerEditorConfigPage::handleHighlighterChanged () {
     languageSettings.setRustSourceSuffixes(rustSuffixesLineEdit->text());
     languageSettings.setOdinSourceSuffixes(odinSuffixesLineEdit->text());
     languageSettings.setAdaSourceSuffixes(adaSuffixesLineEdit->text());
+    languageSettings.setFortranSourceSuffixes(fortranSuffixesLineEdit->text());
 
     // Update our view.
     setHighlighterSettings(languageSettings);

--- a/src/SeerEditorConfigPage.ui
+++ b/src/SeerEditorConfigPage.ui
@@ -272,6 +272,33 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabFortran">
+      <attribute name="title">
+       <string>Fortran</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayoutFortran">
+       <item>
+        <widget class="QLabel" name="fortranLabel">
+         <property name="text">
+          <string>Suffixes:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QHistoryLineEdit" name="fortranSuffixesLineEdit">
+         <property name="toolTip">
+          <string>Fortran source suffixes. Separated by '|'.</string>
+         </property>
+         <property name="placeholderText">
+          <string>Fortran source suffixes.</string>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item row="3" column="0">

--- a/src/SeerFortranSourceHighlighter.cpp
+++ b/src/SeerFortranSourceHighlighter.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 Ernie Pasveer <epasveer@att.net>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "SeerFortranSourceHighlighter.h"
+
+SeerFortranSourceHighlighter::SeerFortranSourceHighlighter(QTextDocument *parent) : SeerSourceHighlighter(parent) {
+
+    // Set to default formats.
+    setHighlighterSettings(SeerHighlighterSettings::populate(""));
+}
+
+void SeerFortranSourceHighlighter::setHighlighterSettings(const SeerHighlighterSettings &settings) {
+
+    _highlighterSettings     = settings;
+
+    _classFormat             = _highlighterSettings.get("Class");
+    _quotationFormat         = _highlighterSettings.get("Quotation");
+    _functionFormat          = _highlighterSettings.get("Function");
+    _singleLineCommentFormat = _highlighterSettings.get("Comment");
+    _multiLineCommentFormat  = _highlighterSettings.get("Multiline Comment");
+    _keywordFormat           = _highlighterSettings.get("Keyword");
+
+    // Free-form Fortran (90 and later).
+    const QString keywordPatterns[] = {
+        QStringLiteral("\\babstract\\b"),     QStringLiteral("\\ballocatable\\b"), QStringLiteral("\\ballocate\\b"),
+        QStringLiteral("\\bassignment\\b"),   QStringLiteral("\\bassociate\\b"),   QStringLiteral("\\basynchronous\\b"),
+        QStringLiteral("\\bbackspace\\b"),    QStringLiteral("\\bbind\\b"),        QStringLiteral("\\bblock\\b"),
+        QStringLiteral("\\bcall\\b"),         QStringLiteral("\\bcase\\b"),        QStringLiteral("\\bcharacter\\b"),
+        QStringLiteral("\\bclass\\b"),        QStringLiteral("\\bclose\\b"),       QStringLiteral("\\bcommon\\b"),
+        QStringLiteral("\\bcomplex\\b"),      QStringLiteral("\\bconcurrent\\b"),  QStringLiteral("\\bcontains\\b"),
+        QStringLiteral("\\bcontinue\\b"),     QStringLiteral("\\bcritical\\b"),    QStringLiteral("\\bcycle\\b"),
+        QStringLiteral("\\bdata\\b"),         QStringLiteral("\\bdeallocate\\b"),  QStringLiteral("\\bdefault\\b"),
+        QStringLiteral("\\bdimension\\b"),    QStringLiteral("\\bdo\\b"),          QStringLiteral("\\bdouble\\b"),
+        QStringLiteral("\\belemental\\b"),    QStringLiteral("\\belse\\b"),        QStringLiteral("\\belseif\\b"),
+        QStringLiteral("\\belsewhere\\b"),    QStringLiteral("\\bend\\b"),         QStringLiteral("\\benddo\\b"),
+        QStringLiteral("\\bendfile\\b"),      QStringLiteral("\\bendif\\b"),       QStringLiteral("\\bentry\\b"),
+        QStringLiteral("\\benum\\b"),         QStringLiteral("\\benumerator\\b"),  QStringLiteral("\\bequivalence\\b"),
+        QStringLiteral("\\berror\\b"),        QStringLiteral("\\bexit\\b"),        QStringLiteral("\\bextends\\b"),
+        QStringLiteral("\\bexternal\\b"),     QStringLiteral("\\bfinal\\b"),       QStringLiteral("\\bforall\\b"),
+        QStringLiteral("\\bformat\\b"),       QStringLiteral("\\bfunction\\b"),    QStringLiteral("\\bgeneric\\b"),
+        QStringLiteral("\\bgoto\\b"),         QStringLiteral("\\bif\\b"),          QStringLiteral("\\bimplicit\\b"),
+        QStringLiteral("\\bimport\\b"),       QStringLiteral("\\binclude\\b"),     QStringLiteral("\\binout\\b"),
+        QStringLiteral("\\binquire\\b"),      QStringLiteral("\\binteger\\b"),     QStringLiteral("\\bintent\\b"),
+        QStringLiteral("\\binterface\\b"),    QStringLiteral("\\bintrinsic\\b"),   QStringLiteral("\\bkind\\b"),
+        QStringLiteral("\\blen\\b"),          QStringLiteral("\\blogical\\b"),     QStringLiteral("\\bmodule\\b"),
+        QStringLiteral("\\bnamelist\\b"),     QStringLiteral("\\bnone\\b"),        QStringLiteral("\\bnullify\\b"),
+        QStringLiteral("\\bonly\\b"),         QStringLiteral("\\bopen\\b"),        QStringLiteral("\\boperator\\b"),
+        QStringLiteral("\\boptional\\b"),     QStringLiteral("\\bparameter\\b"),   QStringLiteral("\\bpointer\\b"),
+        QStringLiteral("\\bprecision\\b"),    QStringLiteral("\\bprint\\b"),       QStringLiteral("\\bprivate\\b"),
+        QStringLiteral("\\bprocedure\\b"),    QStringLiteral("\\bprogram\\b"),     QStringLiteral("\\bprotected\\b"),
+        QStringLiteral("\\bpublic\\b"),       QStringLiteral("\\bpure\\b"),        QStringLiteral("\\bread\\b"),
+        QStringLiteral("\\breal\\b"),         QStringLiteral("\\brecursive\\b"),   QStringLiteral("\\bresult\\b"),
+        QStringLiteral("\\breturn\\b"),       QStringLiteral("\\brewind\\b"),      QStringLiteral("\\bsave\\b"),
+        QStringLiteral("\\bselect\\b"),       QStringLiteral("\\bsequence\\b"),    QStringLiteral("\\bstop\\b"),
+        QStringLiteral("\\bsubmodule\\b"),    QStringLiteral("\\bsubroutine\\b"),  QStringLiteral("\\btarget\\b"),
+        QStringLiteral("\\bthen\\b"),         QStringLiteral("\\btype\\b"),        QStringLiteral("\\buse\\b"),
+        QStringLiteral("\\bvalue\\b"),        QStringLiteral("\\bvolatile\\b"),    QStringLiteral("\\bwhere\\b"),
+        QStringLiteral("\\bwhile\\b"),        QStringLiteral("\\bwrite\\b"),
+        // Dotted logical/relational operators and constants. (The symbolic
+        // forms '==', '/=', ... are left unstyled, like in the C++ highlighter.)
+        QStringLiteral("\\.and\\."),          QStringLiteral("\\.or\\."),          QStringLiteral("\\.not\\."),
+        QStringLiteral("\\.eqv\\."),          QStringLiteral("\\.neqv\\."),        QStringLiteral("\\.true\\."),
+        QStringLiteral("\\.false\\."),        QStringLiteral("\\.eq\\."),          QStringLiteral("\\.ne\\."),
+        QStringLiteral("\\.lt\\."),           QStringLiteral("\\.le\\."),          QStringLiteral("\\.gt\\."),
+        QStringLiteral("\\.ge\\."),
+    };
+
+    _highlightingRules.clear(); // Clear old rules.
+
+    HighlightingRule rule;
+
+    // No class rule: Fortran is case insensitive with no reliable case convention,
+    // and derived types are already covered by the 'type'/'class' keywords.
+
+    // No function rule either: 'name(...)' is also how Fortran references arrays,
+    // so highlighting it as a function call would be wrong half of the time.
+
+    // Set keywords format and expression.
+    // Fortran is case insensitive, so we use case insensitive option.
+    for (const QString &pattern : keywordPatterns) {
+        rule.pattern = QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption);
+        rule.format  = _keywordFormat;
+        _highlightingRules.append(rule);
+    }
+
+    // Set keyword format for the symbolic operators too, so '==' renders like
+    // its word form '.eq.'. Safe in Fortran: no templates, '<'/'>' are always
+    // relational. Two-character operators first in the alternation.
+    rule.pattern = QRegularExpression(QStringLiteral("//|==|/=|<=|>=|=>|<|>"));
+    rule.format  = _keywordFormat;
+    _highlightingRules.append(rule);
+
+    // Set function format for the common intrinsics, when actually called.
+    // A generic before-parenthesis rule is out (see above), but a closed list
+    // of intrinsics followed by '(' is safe. As a side effect, 'len'/'kind'
+    // stay keywords in declarations ('len=32') and become functions in calls.
+    rule.pattern = QRegularExpression(QStringLiteral(
+        "\\b(?:abs|achar|adjustl|adjustr|aimag|allocated|associated|atan2?|ceiling|char|cmplx|conjg|cosh?|count"
+        "|cpu_time|dble|dot_product|epsilon|exp|floor|huge|iachar|index|int|kind|lbound|len|len_trim|log|log10"
+        "|matmul|max|maxval|merge|min|minval|mod|modulo|nint|norm2|pack|present|product|random_number|random_seed"
+        "|real|repeat|reshape|scan|sign|sinh?|size|spread|sqrt|sum|system_clock|tanh?|tiny|transfer|transpose"
+        "|trim|ubound|unpack|verify)\\b(?=\\s*\\()"), QRegularExpression::CaseInsensitiveOption);
+    rule.format  = _functionFormat;
+    _highlightingRules.append(rule);
+
+    // Set quote format and expression. Fortran strings use either quote character.
+    rule.pattern = QRegularExpression(QStringLiteral("\"[^\"]*\""));
+    rule.format  = _quotationFormat;
+    _highlightingRules.append(rule);
+
+    rule.pattern = QRegularExpression(QStringLiteral("'[^']*'"));
+    rule.format  = _quotationFormat;
+    _highlightingRules.append(rule);
+
+    // Set single line comment format and expression. (Fortran uses !)
+    // Note '//' is the string concatenation operator in Fortran, not a comment.
+    rule.pattern = QRegularExpression(QStringLiteral("![^\n]*"));
+    rule.format  = _singleLineCommentFormat;
+    _highlightingRules.append(rule);
+
+    // Multi-line comments are not possible in Fortran.
+    // Using a regex that matches nothing to avoid any unintended highlighting.
+    _commentStartExpression = QRegularExpression(QStringLiteral("(?!)"));
+    _commentEndExpression   = QRegularExpression(QStringLiteral("(?!)"));
+}

--- a/src/SeerFortranSourceHighlighter.h
+++ b/src/SeerFortranSourceHighlighter.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Ernie Pasveer <epasveer@att.net>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "SeerHighlighterSettings.h"
+#include "SeerSourceHighlighter.h"
+
+class SeerFortranSourceHighlighter : public SeerSourceHighlighter {
+
+    Q_OBJECT
+
+    public:
+        SeerFortranSourceHighlighter(QTextDocument *parent = 0);
+
+        virtual void        setHighlighterSettings          (const SeerHighlighterSettings &settings) override;
+};

--- a/src/SeerHighlighterSettings.cpp
+++ b/src/SeerHighlighterSettings.cpp
@@ -23,10 +23,11 @@ SeerHighlighterSettings& SeerHighlighterSettings::operator= (const SeerHighlight
 
     _keys               = rhs._keys;
     _formats            = rhs._formats;
-    _adaSourceSuffixes  = rhs._adaSourceSuffixes;
-    _cppSourceSuffixes  = rhs._cppSourceSuffixes;
-    _rustSourceSuffixes = rhs._rustSourceSuffixes;
-    _odinSourceSuffixes = rhs._odinSourceSuffixes;
+    _adaSourceSuffixes     = rhs._adaSourceSuffixes;
+    _cppSourceSuffixes     = rhs._cppSourceSuffixes;
+    _fortranSourceSuffixes = rhs._fortranSourceSuffixes;
+    _rustSourceSuffixes    = rhs._rustSourceSuffixes;
+    _odinSourceSuffixes    = rhs._odinSourceSuffixes;
 
     return *this;
 }
@@ -87,6 +88,11 @@ void SeerHighlighterSettings::setCppSourceSuffixes (const QString& suffixes) {
     _cppSourceSuffixes = suffixes;
 }
 
+void SeerHighlighterSettings::setFortranSourceSuffixes (const QString& suffixes) {
+
+    _fortranSourceSuffixes = suffixes;
+}
+
 void SeerHighlighterSettings::setOdinSourceSuffixes (const QString& suffixes) {
 
     _odinSourceSuffixes = suffixes;
@@ -100,6 +106,11 @@ void SeerHighlighterSettings::setRustSourceSuffixes (const QString& suffixes) {
 const QString& SeerHighlighterSettings::cppSourceSuffixes () {
 
     return _cppSourceSuffixes;
+}
+
+const QString& SeerHighlighterSettings::fortranSourceSuffixes () {
+
+    return _fortranSourceSuffixes;
 }
 
 const QString& SeerHighlighterSettings::odinSourceSuffixes () {
@@ -245,6 +256,7 @@ SeerHighlighterSettings SeerHighlighterSettings::populate_light () {
 
     languageSettings.setAdaSourceSuffixes(".ada|.adb|.ads");
     languageSettings.setCppSourceSuffixes(".c|.C|.cpp|.CPP|.cxx|.CXX|.h|.H|.hpp|.hxx|.Hxx|.HXX");
+    languageSettings.setFortranSourceSuffixes(".f90|.F90|.f95|.F95|.f03|.F03|.f08|.F08");
     languageSettings.setOdinSourceSuffixes(".odin");
     languageSettings.setRustSourceSuffixes(".rs");
 
@@ -343,6 +355,7 @@ SeerHighlighterSettings SeerHighlighterSettings::populate_dark () {
 
     languageSettings.setAdaSourceSuffixes(".ada|.adb|.ads");
     languageSettings.setCppSourceSuffixes(".c|.C|.cpp|.CPP|.cxx|.CXX|.h|.H|.hpp|.hxx|.Hxx|.HXX");
+    languageSettings.setFortranSourceSuffixes(".f90|.F90|.f95|.F95|.f03|.F03|.f08|.F08");
     languageSettings.setOdinSourceSuffixes(".odin");
     languageSettings.setRustSourceSuffixes(".rs");
 

--- a/src/SeerHighlighterSettings.h
+++ b/src/SeerHighlighterSettings.h
@@ -25,10 +25,12 @@ class SeerHighlighterSettings {
         int                                     count                   () const;
         void                                    setAdaSourceSuffixes    (const QString& suffixes);
         void                                    setCppSourceSuffixes    (const QString& suffixes);
+        void                                    setFortranSourceSuffixes(const QString& suffixes);
         void                                    setOdinSourceSuffixes   (const QString& suffixes);
         void                                    setRustSourceSuffixes   (const QString& suffixes);
         const QString&                          adaSourceSuffixes       ();
         const QString&                          cppSourceSuffixes       ();
+        const QString&                          fortranSourceSuffixes   ();
         const QString&                          odinSourceSuffixes      ();
         const QString&                          rustSourceSuffixes      ();
 
@@ -42,6 +44,7 @@ class SeerHighlighterSettings {
         QList<QTextCharFormat>                  _formats;
         QString                                 _adaSourceSuffixes;
         QString                                 _cppSourceSuffixes;
+        QString                                 _fortranSourceSuffixes;
         QString                                 _odinSourceSuffixes;
         QString                                 _rustSourceSuffixes;
 };

--- a/src/SeerMainWindow.cpp
+++ b/src/SeerMainWindow.cpp
@@ -1800,10 +1800,11 @@ void SeerMainWindow::writeConfigSettings () {
                 } settings.endGroup();
             }
 
-            settings.setValue("cppsuffixes",  highlighter.cppSourceSuffixes());
-            settings.setValue("odinsuffixes", highlighter.odinSourceSuffixes());
-            settings.setValue("rustsuffixes", highlighter.rustSourceSuffixes());
-            settings.setValue("adasuffixes",  highlighter.adaSourceSuffixes());
+            settings.setValue("cppsuffixes",     highlighter.cppSourceSuffixes());
+            settings.setValue("odinsuffixes",    highlighter.odinSourceSuffixes());
+            settings.setValue("rustsuffixes",    highlighter.rustSourceSuffixes());
+            settings.setValue("adasuffixes",     highlighter.adaSourceSuffixes());
+            settings.setValue("fortransuffixes", highlighter.fortranSourceSuffixes());
         } settings.endGroup();
 
     } settings.endGroup();
@@ -1918,10 +1919,11 @@ void SeerMainWindow::readConfigSettings () {
                 } settings.endGroup();
             }
 
-            if (settings.contains("cppsuffixes"))  highlighter.setCppSourceSuffixes(settings.value("cppsuffixes").toString());
-            if (settings.contains("odinsuffixes")) highlighter.setOdinSourceSuffixes(settings.value("odinsuffixes").toString());
-            if (settings.contains("rustsuffixes")) highlighter.setRustSourceSuffixes(settings.value("rustsuffixes").toString());
-            if (settings.contains("adasuffixes"))  highlighter.setAdaSourceSuffixes(settings.value("adasuffixes").toString());
+            if (settings.contains("cppsuffixes"))     highlighter.setCppSourceSuffixes(settings.value("cppsuffixes").toString());
+            if (settings.contains("odinsuffixes"))    highlighter.setOdinSourceSuffixes(settings.value("odinsuffixes").toString());
+            if (settings.contains("rustsuffixes"))    highlighter.setRustSourceSuffixes(settings.value("rustsuffixes").toString());
+            if (settings.contains("adasuffixes"))     highlighter.setAdaSourceSuffixes(settings.value("adasuffixes").toString());
+            if (settings.contains("fortransuffixes")) highlighter.setFortranSourceSuffixes(settings.value("fortransuffixes").toString());
 
             gdbWidget->editorManager()->setEditorHighlighterSettings(highlighter);
 

--- a/src/SeerSourceHighlighter.cpp
+++ b/src/SeerSourceHighlighter.cpp
@@ -6,6 +6,7 @@
 #include "SeerAdaSourceHighlighter.h"
 #include "SeerOdinSourceHighlighter.h"
 #include "SeerCppSourceHighlighter.h"
+#include "SeerFortranSourceHighlighter.h"
 #include "SeerRustSourceHighlighter.h"
 
 SeerSourceHighlighter::SeerSourceHighlighter (QTextDocument* parent) : QSyntaxHighlighter(parent) {}
@@ -24,6 +25,11 @@ SeerSourceHighlighter* SeerSourceHighlighter::getSourceHighlighter(QString const
     QRegularExpression cpp_re("(?:" + settings.cppSourceSuffixes() + ")$");
     if (file.contains(cpp_re)) {
       return new SeerCppSourceHighlighter(0);
+    }
+
+    QRegularExpression fortran_re("(?:" + settings.fortranSourceSuffixes() + ")$");
+    if (file.contains(fortran_re)) {
+      return new SeerFortranSourceHighlighter(0);
     }
 
     QRegularExpression odin_re("(?:" + settings.odinSourceSuffixes() + ")$");

--- a/tests/hellofortran90/Makefile
+++ b/tests/hellofortran90/Makefile
@@ -1,5 +1,5 @@
 # Fortran compiler
-FC = gfortran-12
+FC = gfortran
 FFLAGS = -g
 
 # Source files


### PR DESCRIPTION
### Why

I've been testing MPI debugging with Seer (#60 is on my radar): half the
MPI world writes Fortran, and Seer had no highlighter for it — Fortran
sources show up as plain text.

### What

A `SeerFortranSourceHighlighter` for free-form Fortran (90 and later),
modeled on the Ada one (the other case-insensitive language), plus the
usual plumbing: suffix list in the settings (defaults to
`.f90|.F90|.f95|.F95|.f03|.F03|.f08|.F08`), a Fortran tab in the editor
config page, save/restore of the suffixes, dispatch in the highlighter
factory, CMakeLists.

Fortran-specific choices, for review:

- Comments are `!` only. Note `//` is the string *concatenation* operator
  in Fortran, not a comment — easy trap coming from C.
- Keywords are matched case-insensitively (like Ada). The list covers
  free-form Fortran 90→2008 keywords plus the dotted operators and
  constants (`.and.`, `.eq.`, `.true.`, …).
- The symbolic operators (`==`, `/=`, `<=`, `>=`, `<`, `>`, `//`, `=>`)
  use the keyword format too, so `==` renders like its word form `.eq.`.
  This is safe in Fortran (no templates — `<`/`>` are always relational).
- Strings match with both delimiters (`"..."` and `'...'`).
- No generic "function" rule: `name(...)` is also how Fortran references
  *arrays*, so a before-parenthesis rule would mislabel half the
  identifiers. Instead, a closed list of the common intrinsics
  (`trim`, `sqrt`, `size`, `matmul`, …) gets the function format when
  followed by `(`. A nice side effect: `len`/`kind` stay keywords in
  declarations (`character(len=32)`) and render as functions in calls.
- No "class" rule: the language is case insensitive with no reliable case
  convention; derived types are already caught by the `type`/`class`
  keywords.
- Fixed-form Fortran (F77 `.f`/`.for`, comment in column 1, code starting
  column 7) is out of scope — it would need column-aware rules and the
  legacy dialect is rarely what people debug interactively.

### One small extra

`tests/hellofortran90/Makefile` hardcoded `FC = gfortran-12`, so the test
didn't build on machines with any other gfortran (mine has 13). Changed
it to plain `gfortran` — that also makes it easy to try this highlighter
on that test.

### Testing

Qt 6.4.2, Linux Mint, gfortran 13. Verified on `tests/hellofortran90`
(which now builds out of the box, see above) and on a dedicated test
sheet exercising the traps above (mixed-case keywords, `//` concat not
colored as comment, both string delimiters, dotted operators).
Screenshot below. The other languages' highlighting is untouched (the
factory just gains one branch).
<img width="1083" height="938" alt="Capture d’écran du 2026-08-11 11-45-14" src="https://github.com/user-attachments/assets/eacd882a-70e1-4c93-8632-51797074c40f" />
<img width="1084" height="943" alt="Capture d’écran du 2026-08-11 11-46-31" src="https://github.com/user-attachments/assets/de1bbaa2-fe56-44fa-9997-4f44085428a1" />

