### PR TITLE
Re-evaluate the visualized variable's address on refresh

### DIFF
--- a/src/SeerArrayVisualizerWidget.cpp
+++ b/src/SeerArrayVisualizerWidget.cpp
@@ -430,8 +430,10 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
                 }
             }
 
-            // Set the variable address.
+            // Set the variable address and read the memory there.
             setAVariableAddress(address);
+
+            readaMemory();
         }
 
         if (id_text.toInt() == _aLengthId) {
@@ -489,8 +491,10 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
                 }
             }
 
-            // Set the variable address.
+            // Set the variable address and read the memory there.
             setBVariableAddress(address);
+
+            readbMemory();
         }
 
         if (id_text.toInt() == _bLengthId) {
@@ -742,6 +746,26 @@ void SeerArrayVisualizerWidget::handleaRefreshButton () {
         return;
     }
 
+    // Re-evaluate the variable's address first: it may have changed since the
+    // last stop (or the variable may not have existed yet). The answer then
+    // reads the memory at the fresh address. See readaMemory().
+    emit evaluateVariableExpression(_aVariableId, aVariableNameLineEdit->text());
+}
+
+void SeerArrayVisualizerWidget::handlebRefreshButton () {
+
+    if (bVariableNameLineEdit->text() == "") {
+        return;
+    }
+
+    // Re-evaluate the variable's address first: it may have changed since the
+    // last stop (or the variable may not have existed yet). The answer then
+    // reads the memory at the fresh address. See readbMemory().
+    emit evaluateVariableExpression(_bVariableId, bVariableNameLineEdit->text());
+}
+
+void SeerArrayVisualizerWidget::readaMemory () {
+
     if (aVariableAddressLineEdit->text() == "") {
         return;
     }
@@ -750,18 +774,25 @@ void SeerArrayVisualizerWidget::handleaRefreshButton () {
         return;
     }
 
+    // A null address can't be read (a std::vector before its construction,
+    // for example). Keep the "0x0" visible but don't ask gdb.
+    if (aVariableAddressLineEdit->text() == "0x0") {
+        return;
+    }
+
     int bytes = aArrayLengthLineEdit->text().toInt() * Seer::typeBytes(aArrayDisplayFormatComboBox->currentText());
+
+    // Nothing to read yet (no length).
+    if (bytes <= 0) {
+        return;
+    }
 
     //qDebug() << _aMemoryId << aVariableAddressLineEdit->text() << aArrayLengthLineEdit->text() << aArrayDisplayFormatComboBox->currentText() << bytes;
 
     emit evaluateMemoryExpression(_aMemoryId, aVariableAddressLineEdit->text(), bytes);
 }
 
-void SeerArrayVisualizerWidget::handlebRefreshButton () {
-
-    if (bVariableNameLineEdit->text() == "") {
-        return;
-    }
+void SeerArrayVisualizerWidget::readbMemory () {
 
     if (bVariableAddressLineEdit->text() == "") {
         return;
@@ -771,7 +802,18 @@ void SeerArrayVisualizerWidget::handlebRefreshButton () {
         return;
     }
 
+    // A null address can't be read (a std::vector before its construction,
+    // for example). Keep the "0x0" visible but don't ask gdb.
+    if (bVariableAddressLineEdit->text() == "0x0") {
+        return;
+    }
+
     int bytes = bArrayLengthLineEdit->text().toInt() * Seer::typeBytes(bArrayDisplayFormatComboBox->currentText());
+
+    // Nothing to read yet (no length).
+    if (bytes <= 0) {
+        return;
+    }
 
     //qDebug() << _bMemoryId << bVariableAddressLineEdit->text() << bArrayLengthLineEdit->text() << bArrayDisplayFormatComboBox->currentText() << bytes;
 

--- a/src/SeerArrayVisualizerWidget.h
+++ b/src/SeerArrayVisualizerWidget.h
@@ -76,6 +76,8 @@ class SeerArrayVisualizerWidget : public QWidget, protected Ui::SeerArrayVisuali
         void                resizeEvent                         (QResizeEvent* event);
 
     private:
+        void                readaMemory                         ();
+        void                readbMemory                         ();
         void                createASeries                       ();
         void                createBSeries                       ();
 

--- a/src/SeerMatrixVisualizerWidget.cpp
+++ b/src/SeerMatrixVisualizerWidget.cpp
@@ -238,8 +238,10 @@ void SeerMatrixVisualizerWidget::handleText (const QString& text) {
                 }
             }
 
-            // Set the variable address.
+            // Set the variable address and read the memory there.
             setVariableAddress(address);
+
+            readMemory();
         }
 
         if (id_text.toInt() == _rowsId) {
@@ -436,6 +438,14 @@ void SeerMatrixVisualizerWidget::handleRefreshButton () {
         return;
     }
 
+    // Re-evaluate the variable's address first: it may have changed since the
+    // last stop (or the variable may not have existed yet). The answer then
+    // reads the memory at the fresh address. See readMemory().
+    emit evaluateVariableExpression(_variableId, variableNameLineEdit->text());
+}
+
+void SeerMatrixVisualizerWidget::readMemory () {
+
     if (variableAddressLineEdit->text() == "") {
         return;
     }
@@ -444,7 +454,18 @@ void SeerMatrixVisualizerWidget::handleRefreshButton () {
         return;
     }
 
+    // A null address can't be read (a matrix before its construction, for
+    // example). Keep the "0x0" visible but don't ask gdb.
+    if (variableAddressLineEdit->text() == "0x0") {
+        return;
+    }
+
     int bytes = matrixRowsLineEdit->text().toInt() * matrixColumnsLineEdit->text().toInt() * Seer::typeBytes(matrixDisplayFormatComboBox->currentText());
+
+    // Nothing to read yet (no rows/columns).
+    if (bytes <= 0) {
+        return;
+    }
 
     // qDebug() << "Asking for" << bytes << "bytes of matrix data.";
 

--- a/src/SeerMatrixVisualizerWidget.h
+++ b/src/SeerMatrixVisualizerWidget.h
@@ -55,6 +55,8 @@ class SeerMatrixVisualizerWidget : public QWidget, protected Ui::SeerMatrixVisua
         void                resizeEvent                             (QResizeEvent* event);
 
     private:
+        void                readMemory                              ();
+
         int                 _variableId;
         int                 _memoryId;
         int                 _rowsId;


### PR DESCRIPTION
### Problem

The Array and Matrix visualizers evaluate the variable's address only
when the name is typed. Every refresh — the manual button as well as the
auto-refresh at each stop (#496/#498) — then re-reads memory at that
stored address, and never re-evaluates the name. So whenever the
variable's address changes, the plot silently shows stale (or wrong)
memory, and no amount of refreshing heals it:

- Enter `&pos[0]` for a `std::vector` *before* it is constructed (e.g.
  before Run, or at an early breakpoint): the address evaluates to `0x0`
  and is trapped forever — every subsequent stop re-reads address 0 and
  pops "Unable to read memory", even though the vector now exists.
- A vector that reallocates (push_back, resize) between two stops: the
  visualizer keeps plotting the *old* buffer — plausible-looking but
  dead data, with no error at all.
- Same story after a re-Run of the program (fresh stack/heap addresses).

### Fix

Split the refresh in two steps. The refresh handlers now re-evaluate the
variable *name*, and the `^done` answer reads the memory at the fresh
address (new `readaMemory()`/`readbMemory()`/`readMemory()` holding the
previous read logic). Since every refresh path funnels through the same
handlers — the manual Refresh button, the auto-refresh at each stop, and
the length/rows/columns/offset/stride changes — they all pick up the
fresh address now. A nice side effect: re-typing the *name* while
stopped refreshes the plot immediately, instead of only updating the
address field.

The read step is skipped for a null address or an empty length: a
not-yet-constructed variable now shows its `0x0` address quietly and the
plot simply appears at the first stop where the variable exists, instead
of raising a memory error at every interaction.

### Testing

Qt 6.4.2, Linux Mint. With a 4000-point `std::vector` phase portrait
(scatter, Auto checked):

1. Enter `&pos[0]`/`&vit[0]` at an early breakpoint (vectors not yet
   constructed), address shows `0x0` → Continue to the filling
   breakpoint, or simply hit Refresh: the address updates and the plot
   appears (previously: "Unable to read memory" on every stop and every
   refresh, forever).
2. Normal flow (names entered at a healthy breakpoint): stepping and
   Continue refresh exactly as before.
3. Matrix Visualizer: same two scenarios on an Eigen matrix.
4. Line/spline/scatter modes unaffected.

<img width="1917" height="1074" alt="Capture d’écran du 2026-08-13 13-42-58" src="https://github.com/user-attachments/assets/68f49435-9514-449e-b92b-787452801bbd" />

<img width="1918" height="1074" alt="Capture d’écran du 2026-08-13 13-43-17" src="https://github.com/user-attachments/assets/557b0328-59a4-4c95-9ce0-37b33ae8824f" />



