### PR TITLE
Improve/openocd goto definition linux

### DIFF
--- a/src/SeerCommandLogsWidget.cpp
+++ b/src/SeerCommandLogsWidget.cpp
@@ -16,6 +16,7 @@
 #include <QtWidgets/QWidgetAction>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
+#include <QtGui/QWheelEvent>
 
 #include <QWidgetAction>
 
@@ -112,6 +113,10 @@ SeerCommandLogsWidget::SeerCommandLogsWidget (QWidget* parent) : QWidget(parent)
     QObject::connect(helpToolButton,                    &QToolButton::clicked,                          this,   &SeerCommandLogsWidget::handleHelpToolButtonClicked);
     QObject::connect(macroButtonGroup,                  &QButtonGroup::buttonClicked,                   this,   &SeerCommandLogsWidget::handleMacroToolButtonClicked);
     QObject::connect(qApp,                              &QCoreApplication::aboutToQuit,                 this,   &SeerCommandLogsWidget::handleAboutToQuit);
+
+    // Install event filter to swallow wheel events on the tab bar if the number of tabs is greater than the number of visible tabs.
+    SeerCommandLogsEventFilter* eventFilterHandler = new SeerCommandLogsEventFilter(logsTabWidget, this);
+    logsTabWidget->tabBar()->installEventFilter(eventFilterHandler);
 }
 
 SeerCommandLogsWidget::~SeerCommandLogsWidget () {
@@ -765,4 +770,30 @@ void SeerCommandLogsWidget::handleTabsContextMenuButtonClicked() {
 
 QDetachTabWidget* SeerCommandLogsWidget::logsTabWidgetInstance () {
     return logsTabWidget;
+}
+
+bool SeerCommandLogsEventFilter::eventFilter(QObject *watched, QEvent *event) {
+
+    if (event->type() == QEvent::Wheel) {
+
+        // Count the number of visible tabs.
+        int visibleCount = 0;
+
+        for (int i=0; i<_tabWidget->count(); i++) {
+            if (_tabWidget->isTabVisible(i)) {
+                visibleCount++;
+            }
+        }
+
+        int index = _tabWidget->currentIndex();
+
+        QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
+
+        // Swallow the wheel event only if it would move past the last visible tab, to avoid landing on a hidden one.
+        if (wheelEvent->angleDelta().y() < 0 && index >= visibleCount - 1) {
+            return true;
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
 }

--- a/src/SeerCommandLogsWidget.h
+++ b/src/SeerCommandLogsWidget.h
@@ -14,6 +14,7 @@
 #include "SeerPrintpointsBrowserWidget.h"
 #include "SeerCheckpointsBrowserWidget.h"
 #include <QtWidgets/QWidget>
+#include <QtWidgets/QTabWidget>
 
 #include "ui_SeerCommandLogsWidget.h"
 
@@ -95,5 +96,20 @@ class SeerCommandLogsWidget : public QWidget, protected Ui::SeerCommandLogsWidge
         SeerCheckpointsBrowserWidget*       _checkpointsBrowserWidget;
         SeerGdbLogWidget*                   _gdbOutputLog;
         SeerSeerLogWidget*                  _seerOutputLog;
+};
+
+class SeerCommandLogsEventFilter : public QObject {
+
+    Q_OBJECT
+
+    public:
+        explicit SeerCommandLogsEventFilter(QTabWidget* tabWidget, QObject *parent = nullptr) : QObject(parent), _tabWidget(tabWidget) {}
+       ~SeerCommandLogsEventFilter() = default;
+
+    protected:
+        bool                                            eventFilter                             (QObject *watched, QEvent *event) override;
+
+    private:
+        QTabWidget*                                     _tabWidget;
 };
 

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -1936,7 +1936,12 @@ void SeerGdbWidget::handleGdbExecutableTypes (int id, const QString& typeRegex) 
 
     //qDebug() << id << typeRegex;
 
-    handleGdbCommand(QString("%1-symbol-info-types --name %2").arg(id).arg(typeRegex));
+    // If openocd is running, then let _gdbLiveWatchProcess handles it
+    if (executableLaunchMode() == "openocd") {
+        _openocdWidget->gdbLiveWatchRunCommand(QString("%1-symbol-info-types --name %2").arg(id).arg(typeRegex));
+    }
+    else
+        handleGdbCommand(QString("%1-symbol-info-types --name %2").arg(id).arg(typeRegex));
 }
 
 void SeerGdbWidget::handleGdbExecutableVariables (int id, const QString& variableNameRegex, const QString& variableTypeRegex) {
@@ -1963,7 +1968,12 @@ void SeerGdbWidget::handleGdbExecutableVariables (int id, const QString& variabl
         command += QString(" --type %1").arg(variableTypeRegex);
     }
 
-    handleGdbCommand(command);
+    // If openocd is running, then let _gdbLiveWatchProcess handles it
+    if (executableLaunchMode() == "openocd") {
+        _openocdWidget->gdbLiveWatchRunCommand(command);
+    }
+    else
+        handleGdbCommand(command);
 }
 
 void SeerGdbWidget::handleGdbExecutableLibraries () {

--- a/src/SeerSourceSymbolLibraryManagerWidget.cpp
+++ b/src/SeerSourceSymbolLibraryManagerWidget.cpp
@@ -12,6 +12,7 @@
 #include <QtGui/QIcon>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
+#include <QtGui/QWheelEvent>
 
 SeerSourceSymbolLibraryManagerWidget::SeerSourceSymbolLibraryManagerWidget (QWidget* parent) : QWidget(parent) {
 
@@ -70,6 +71,10 @@ SeerSourceSymbolLibraryManagerWidget::SeerSourceSymbolLibraryManagerWidget (QWid
     QObject::connect(helpToolButton,        &QToolButton::clicked,     this,  &SeerSourceSymbolLibraryManagerWidget::handleHelpToolButtonClicked);
     QObject::connect(tabWidget->tabBar(),   &QTabBar::tabMoved,        this,  &SeerSourceSymbolLibraryManagerWidget::handleTabMoved);
     QObject::connect(tabWidget->tabBar(),   &QTabBar::currentChanged,  this,  &SeerSourceSymbolLibraryManagerWidget::handleTabChanged);
+
+    // Install event filter to swallow wheel events on the tab bar if the number of tabs is greater than the number of visible tabs.
+    SeerSourceSymbolLibraryEventFilter* eventFilterHandler = new SeerSourceSymbolLibraryEventFilter(tabWidget, this);
+    tabWidget->tabBar()->installEventFilter(eventFilterHandler);
 }
 
 SeerSourceSymbolLibraryManagerWidget::~SeerSourceSymbolLibraryManagerWidget () {
@@ -289,3 +294,27 @@ void SeerSourceSymbolLibraryManagerWidget::handleTabsContextMenuButtonClicked() 
     contextMenu.exec(QCursor::pos());
 }
 
+bool SeerSourceSymbolLibraryEventFilter::eventFilter(QObject *watched, QEvent *event) {
+
+    if (event->type() == QEvent::Wheel) {
+
+        // Count the number of visible tabs.
+        int visibleCount = 0;
+
+        for (int i=0; i<_tabWidget->count(); i++) {
+            if (_tabWidget->isTabVisible(i)) {
+                visibleCount++;
+            }
+        }
+
+        int index = _tabWidget->currentIndex();
+
+        QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
+
+        // Swallow the wheel event only if it would move past the last visible tab, to avoid landing on a hidden one.
+        if (wheelEvent->angleDelta().y() < 0 && index >= visibleCount - 1) {
+            return true;
+        }
+    }
+    return QObject::eventFilter(watched, event);
+}

--- a/src/SeerSourceSymbolLibraryManagerWidget.h
+++ b/src/SeerSourceSymbolLibraryManagerWidget.h
@@ -13,6 +13,7 @@
 #include "SeerSkipBrowserWidget.h"
 
 #include <QtWidgets/QWidget>
+#include <QtWidgets/QTabWidget>
 
 #include "ui_SeerSourceSymbolLibraryManagerWidget.h"
 
@@ -54,3 +55,17 @@ class SeerSourceSymbolLibraryManagerWidget : public QWidget, protected Ui::SeerS
         QTabWidget*                                     _dumpTab;
 };
 
+class SeerSourceSymbolLibraryEventFilter : public QObject {
+
+    Q_OBJECT
+
+    public:
+        explicit SeerSourceSymbolLibraryEventFilter(QTabWidget* tabWidget, QObject *parent = nullptr) : QObject(parent), _tabWidget(tabWidget) {}
+       ~SeerSourceSymbolLibraryEventFilter() = default;
+
+    protected:
+        bool                                            eventFilter                             (QObject *watched, QEvent *event) override;
+
+    private:
+        QTabWidget*                                     _tabWidget;
+};

--- a/src/SeerStackManagerWidget.cpp
+++ b/src/SeerStackManagerWidget.cpp
@@ -13,6 +13,7 @@
 #include <QtGui/QIcon>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
+#include <QtGui/QWheelEvent>
 
 SeerStackManagerWidget::SeerStackManagerWidget (QWidget* parent) : QWidget(parent) {
 
@@ -65,6 +66,10 @@ SeerStackManagerWidget::SeerStackManagerWidget (QWidget* parent) : QWidget(paren
     QObject::connect(helpToolButton,        &QToolButton::clicked,         this,  &SeerStackManagerWidget::handleHelpToolButtonClicked);
     QObject::connect(tabWidget->tabBar(),   &QTabBar::tabMoved,            this,  &SeerStackManagerWidget::handleTabMoved);
     QObject::connect(tabWidget->tabBar(),   &QTabBar::currentChanged,      this,  &SeerStackManagerWidget::handleTabChanged);
+
+    // Install event filter to swallow wheel events on the tab bar if the number of tabs is greater than the number of visible tabs.
+    SeerStackManagerEventFilter* eventFilterHandler = new SeerStackManagerEventFilter(tabWidget, this);
+    tabWidget->tabBar()->installEventFilter(eventFilterHandler);
 }
 
 SeerStackManagerWidget::~SeerStackManagerWidget () {
@@ -330,4 +335,29 @@ void SeerStackManagerWidget::handleTabsContextMenuButtonClicked() {
     contextMenu.exec(QCursor::pos());
 }
 
+bool SeerStackManagerEventFilter::eventFilter(QObject *watched, QEvent *event) {
+
+    if (event->type() == QEvent::Wheel) {
+
+        // Count the number of visible tabs.
+        int visibleCount = 0;
+
+        for (int i=0; i<_tabWidget->count(); i++) {
+            if (_tabWidget->isTabVisible(i)) {
+                visibleCount++;
+            }
+        }
+
+        int index = _tabWidget->currentIndex();
+
+        QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
+
+        // Swallow the wheel event only if it would move past the last visible tab, to avoid landing on a hidden one.
+        if (wheelEvent->angleDelta().y() < 0 && index >= visibleCount - 1) {
+            return true;
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
+}
 

--- a/src/SeerStackManagerWidget.h
+++ b/src/SeerStackManagerWidget.h
@@ -10,6 +10,7 @@
 #include "SeerStackDumpBrowserWidget.h"
 
 #include <QtWidgets/QWidget>
+#include <QtWidgets/QTabWidget>
 
 #include "ui_SeerStackManagerWidget.h"
 
@@ -51,5 +52,20 @@ class SeerStackManagerWidget : public QWidget, protected Ui::SeerStackManagerWid
         SeerStackArgumentsBrowserWidget*                _stackArgumentsBrowserWidget;
         SeerStackLocalsBrowserWidget*                   _stackLocalsBrowserWidget;
         SeerStackDumpBrowserWidget*                     _stackDumpBrowserWidget;
+};
+
+class SeerStackManagerEventFilter : public QObject {
+
+    Q_OBJECT
+
+    public:
+        explicit SeerStackManagerEventFilter(QTabWidget* tabWidget, QObject *parent = nullptr) : QObject(parent), _tabWidget(tabWidget) {}
+       ~SeerStackManagerEventFilter() = default;
+
+    protected:
+        bool                                            eventFilter                             (QObject *watched, QEvent *event) override;
+
+    private:
+        QTabWidget*                                     _tabWidget;
 };
 

--- a/src/SeerThreadManagerWidget.cpp
+++ b/src/SeerThreadManagerWidget.cpp
@@ -14,6 +14,7 @@
 #include <QtCore/QFile>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
+#include <QtGui/QWheelEvent>
 
 SeerThreadManagerWidget::SeerThreadManagerWidget (QWidget* parent) : QWidget(parent) {
 
@@ -69,6 +70,10 @@ SeerThreadManagerWidget::SeerThreadManagerWidget (QWidget* parent) : QWidget(par
     QObject::connect(forkFollowsComboBox,      QOverload<int>::of(&QComboBox::currentIndexChanged),     this,  &SeerThreadManagerWidget::handleForkFollowComboBox);
     QObject::connect(tabWidget->tabBar(),      &QTabBar::tabMoved,                                      this,  &SeerThreadManagerWidget::handleTabMoved);
     QObject::connect(tabWidget->tabBar(),      &QTabBar::currentChanged,                                this,  &SeerThreadManagerWidget::handleTabChanged);
+
+    // Install event filter to swallow wheel events on the tab bar if the number of tabs is greater than the number of visible tabs.
+    SeerThreadManagerEventFilter* eventFilterHandler = new SeerThreadManagerEventFilter(tabWidget, this);
+    tabWidget->tabBar()->installEventFilter(eventFilterHandler);
 }
 
 SeerThreadManagerWidget::~SeerThreadManagerWidget () {
@@ -321,5 +326,31 @@ void SeerThreadManagerWidget::handleTabsContextMenuButtonClicked() {
     contextMenu.addAction(action);
 
     contextMenu.exec(QCursor::pos());
+}
+
+bool SeerThreadManagerEventFilter::eventFilter(QObject *watched, QEvent *event) {
+
+    if (event->type() == QEvent::Wheel) {
+
+        // Count the number of visible tabs.
+        int visibleCount = 0;
+
+        for (int i=0; i<_tabWidget->count(); i++) {
+            if (_tabWidget->isTabVisible(i)) {
+                visibleCount++;
+            }
+        }
+
+        int index = _tabWidget->currentIndex();
+
+        QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
+
+        // Swallow the wheel event only if it would move past the last visible tab, to avoid landing on a hidden one.
+        if (wheelEvent->angleDelta().y() < 0 && index >= visibleCount - 1) {
+            return true;
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
 }
 

--- a/src/SeerThreadManagerWidget.h
+++ b/src/SeerThreadManagerWidget.h
@@ -10,6 +10,7 @@
 #include "SeerAdaTasksBrowserWidget.h"
 
 #include <QtWidgets/QWidget>
+#include <QtWidgets/QTabWidget>
 
 #include "ui_SeerThreadManagerWidget.h"
 
@@ -60,5 +61,20 @@ class SeerThreadManagerWidget : public QWidget, protected Ui::SeerThreadManagerW
         SeerThreadIdsBrowserWidget*                     _threadIdsBrowserWidget;
         SeerThreadGroupsBrowserWidget*                  _threadGroupsBrowserWidget;
         SeerAdaTasksBrowserWidget*                      _adaTasksBrowserWidget;
+};
+
+class SeerThreadManagerEventFilter : public QObject {
+
+    Q_OBJECT
+
+    public:
+        explicit SeerThreadManagerEventFilter(QTabWidget* tabWidget, QObject *parent = nullptr) : QObject(parent), _tabWidget(tabWidget) {}
+       ~SeerThreadManagerEventFilter() = default;
+
+    protected:
+        bool                                            eventFilter                             (QObject *watched, QEvent *event) override;
+
+    private:
+        QTabWidget*                                     _tabWidget;
 };
 

--- a/src/SeerVariableManagerWidget.cpp
+++ b/src/SeerVariableManagerWidget.cpp
@@ -12,6 +12,7 @@
 #include <QtGui/QIcon>
 #include <QtCore/QSettings>
 #include <QtCore/QDebug>
+#include <QtGui/QWheelEvent>
 
 SeerVariableManagerWidget::SeerVariableManagerWidget (QWidget* parent) : QWidget(parent) {
 
@@ -66,6 +67,10 @@ SeerVariableManagerWidget::SeerVariableManagerWidget (QWidget* parent) : QWidget
     QObject::connect(tabWidget->tabBar(),           &QTabBar::currentChanged,                       this,  &SeerVariableManagerWidget::handleTabChanged);
     QObject::connect(_variableLoggerBrowserWidget,  &SeerVariableLoggerBrowserWidget::raiseTab,     this,  &SeerVariableManagerWidget::handleRaiseLoggerTab);
     QObject::connect(_variableTrackerBrowserWidget, &SeerVariableTrackerBrowserWidget::raiseTab,    this,  &SeerVariableManagerWidget::handleRaiseTrackerTab);
+
+    // Install event filter to swallow wheel events on the tab bar if the number of tabs is greater than the number of visible tabs.
+    SeerVariableManagerEventFilter* eventFilterHandler = new SeerVariableManagerEventFilter(tabWidget, this);
+    tabWidget->tabBar()->installEventFilter(eventFilterHandler);
 }
 
 SeerVariableManagerWidget::~SeerVariableManagerWidget () {
@@ -288,5 +293,31 @@ void SeerVariableManagerWidget::handleTabsContextMenuButtonClicked() {
     contextMenu.addAction(action);
 
     contextMenu.exec(QCursor::pos());
+}
+
+bool SeerVariableManagerEventFilter::eventFilter(QObject *watched, QEvent *event) {
+
+    if (event->type() == QEvent::Wheel) {
+
+        // Count the number of visible tabs.
+        int visibleCount = 0;
+
+        for (int i=0; i<_tabWidget->count(); i++) {
+            if (_tabWidget->isTabVisible(i)) {
+                visibleCount++;
+            }
+        }
+
+        int index = _tabWidget->currentIndex();
+
+        QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
+
+        // Swallow the wheel event only if it would move past the last visible tab, to avoid landing on a hidden one.
+        if (wheelEvent->angleDelta().y() < 0 && index >= visibleCount - 1) {
+            return true;
+        }
+    }
+
+    return QObject::eventFilter(watched, event);
 }
 

--- a/src/SeerVariableManagerWidget.h
+++ b/src/SeerVariableManagerWidget.h
@@ -10,6 +10,7 @@
 #include "SeerSignalValuesBrowserWidget.h"
 
 #include <QtWidgets/QWidget>
+#include <QtWidgets/QTabWidget>
 
 #include "ui_SeerVariableManagerWidget.h"
 
@@ -44,5 +45,20 @@ class SeerVariableManagerWidget : public QWidget, protected Ui::SeerVariableMana
         SeerVariableLoggerBrowserWidget*                _variableLoggerBrowserWidget;
         SeerRegisterValuesBrowserWidget*                _registerValuesBrowserWidget;
         SeerSignalValuesBrowserWidget*                  _signalValuesBrowserWidget;
+};
+
+class SeerVariableManagerEventFilter : public QObject {
+
+    Q_OBJECT
+
+    public:
+        explicit SeerVariableManagerEventFilter(QTabWidget* tabWidget, QObject *parent = nullptr) : QObject(parent), _tabWidget(tabWidget) {}
+       ~SeerVariableManagerEventFilter() = default;
+
+    protected:
+        bool                                            eventFilter                             (QObject *watched, QEvent *event) override;
+
+    private:
+        QTabWidget*                                     _tabWidget;
 };
 


### PR DESCRIPTION
I've committed 2 fixes in this PR
1. As I disscussed previously, I should let openocd gdb handle go to definition feature. But the PR https://github.com/epasveer/seer/pull/512 only handles go to definition function. This MR will support types and variables
2. I found a bug in this:
<img width="255" height="135" alt="image" src="https://github.com/user-attachments/assets/954dc0cb-9bd2-46b9-a2f2-19451903b192" />
Explain: When I scroll my mouse, the index of tabwidget changes, so the point on the above image shows properties of the children tab.
This issue appears all tabwidget that deploy Show/Hide tabs:
SeerSourceSymbolLibraryEventFilter
SeerCommandLogsWidget
SeerStackManagerWidget
SeerThreadManagerWidget
SeerVariableManagerWidget
-> To fix: filter out the mouse scroll event, check the index of tabwidget. If index > number of visible tabs, then bypass.