### PR TITLE
Fix the Image Visualizer zoom keys under Qt6

### DIFF
--- a/src/QImageViewer.cpp
+++ b/src/QImageViewer.cpp
@@ -19,6 +19,8 @@
 
 QImageViewer::QImageViewer (QWidget* parent) : QWidget(parent) {
 
+    setFocusPolicy(Qt::StrongFocus); // So the widget can take focus and receive the +/-/ESC zoom keys.
+
     _zoomFactor = 1.0;
 
     // Setup the widgets
@@ -174,7 +176,7 @@ void QImageViewer::keyPressEvent (QKeyEvent* event) {
     }
 }
 
-void QImageViewer::enterEvent (QEvent* event) {
+void QImageViewer::enterEvent (QEnterEvent* event) {
 
     Q_UNUSED(event);
 

--- a/src/QImageViewer.h
+++ b/src/QImageViewer.h
@@ -38,8 +38,8 @@ class QImageViewer : public QWidget {
 
     protected slots:
         void                    keyPressEvent           (QKeyEvent* event);
-        void                    enterEvent              (QEvent*    event);
-        void                    leaveEvent              (QEvent*    event);
+        void                    enterEvent              (QEnterEvent* event) override;
+        void                    leaveEvent              (QEvent*    event) override;
 
     private:
         QImage                  _image;


### PR DESCRIPTION
### Problem

The Image Visualizer help promises `+` / `-` / `ESC` to zoom, but under
Qt6 none of them do anything.

Cause: Qt6 changed the virtual's signature from `enterEvent(QEvent*)`
to `enterEvent(QEnterEvent*)`. `QImageViewer::enterEvent(QEvent*)` no
longer overrides anything, so it is never called, the widget never takes
focus when the mouse enters it, and the key presses never reach
`keyPressEvent()`. (The parallel stacks visualizer already uses the Qt6
signature with `override` — which is exactly the keyword that would have
turned this silent break into a compile error.)

### Fix

- `enterEvent(QEnterEvent*)` with `override` (and `override` on
  `leaveEvent` while touching the lines).
- `setFocusPolicy(Qt::StrongFocus)` in the constructor, like the other
  focus-taking Seer widgets, so the viewer can also be focused by click
  or Tab.

### Testing

Qt 6.4.2, Linux Mint. Image Visualizer on a test image in memory:
hover the image, `+` zooms in, `-` zooms out, `ESC` resets — matching
the help page again. Scrolling of the zoomed image unchanged.
<img width="2544" height="1396" alt="Capture d’écran du 2026-08-14 12-42-26" src="https://github.com/user-attachments/assets/39b97c3e-260e-49be-9109-d6a9c7ee807e" />
<img width="2552" height="1393" alt="Capture d’écran du 2026-08-14 12-42-40" src="https://github.com/user-attachments/assets/447e39b8-df46-4652-9d59-2953daf8cf9f" />

One note: the mouse wheel scrolls the (zoomed) image but does not zoom.
That matches the documented behavior (zoom is on the keys), but if you'd
like Ctrl+wheel zoom — the usual idiom elsewhere — I'm happy to follow
up with a small separate PR.
