### PR TITLE
Add Ctrl+wheel zoom to the Image Visualizer

### DIFF
--- a/src/QImageViewer.cpp
+++ b/src/QImageViewer.cpp
@@ -9,6 +9,7 @@
 #include <QtGui/QImageReader>
 #include <QtGui/QImageWriter>
 #include <QtGui/QPainter>
+#include <QtGui/QWheelEvent>
 #include <QtCore/QDebug>
 #include <QtPrintSupport/QPrintDialog>
 
@@ -35,6 +36,10 @@ QImageViewer::QImageViewer (QWidget* parent) : QWidget(parent) {
     _scrollArea->setBackgroundRole(QPalette::Dark);
     _scrollArea->setWidget(_imageLabel);
     _scrollArea->setWidgetResizable(false);
+
+    // The scroll area consumes wheel events for scrolling, so watch its
+    // viewport to catch Ctrl+wheel for zooming.
+    _scrollArea->viewport()->installEventFilter(this);
 
     layout->addWidget(_scrollArea);
 
@@ -174,6 +179,29 @@ void QImageViewer::keyPressEvent (QKeyEvent* event) {
             QWidget::keyPressEvent(event);
             break;
     }
+}
+
+bool QImageViewer::eventFilter (QObject* object, QEvent* event) {
+
+    // Ctrl+wheel over the image zooms in or out. A plain wheel keeps
+    // scrolling the image as usual.
+    if (object == _scrollArea->viewport() && event->type() == QEvent::Wheel) {
+
+        QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
+
+        if (wheelEvent->modifiers() & Qt::ControlModifier) {
+
+            if (wheelEvent->angleDelta().y() > 0) {
+                zoomIn();
+            }else if (wheelEvent->angleDelta().y() < 0) {
+                zoomOut();
+            }
+
+            return true;
+        }
+    }
+
+    return QWidget::eventFilter(object, event);
 }
 
 void QImageViewer::enterEvent (QEnterEvent* event) {

--- a/src/QImageViewer.h
+++ b/src/QImageViewer.h
@@ -38,6 +38,7 @@ class QImageViewer : public QWidget {
 
     protected slots:
         void                    keyPressEvent           (QKeyEvent* event);
+        bool                    eventFilter             (QObject* object, QEvent* event) override;
         void                    enterEvent              (QEnterEvent* event) override;
         void                    leaveEvent              (QEvent*    event) override;
 

--- a/src/resources/help/ImageVisualizer.md
+++ b/src/resources/help/ImageVisualizer.md
@@ -78,5 +78,6 @@ Available Quick keys while in the Image Visualizer:
     '+'   zoom in
     '-'   zoom out
     ESC   reset to default zoom level.
+    Ctrl+mouse wheel   zoom in or out.
 ```
 


### PR DESCRIPTION
Follow-up to #520, as discussed there.

Ctrl+mouse wheel now zooms the image in and out, consistent with the
Array Visualizer plots. A plain wheel keeps scrolling the zoomed image
as before.

Implementation note: the scroll area consumes wheel events for
scrolling, so the Ctrl+wheel case is caught with an event filter on its
viewport rather than a `wheelEvent` override (which would never see the
event once the scroll bars are active).

The help page gains a line documenting the new shortcut.

### Testing

Qt 6.4.2, Linux Mint, with the RGBA/RGB test images: Ctrl+wheel zooms
both ways, plain wheel scrolls the zoomed image, `+`/`-`/`ESC` unchanged.