### PR TITLE
Fix openocd segmentfault

### DIFF
--- a/src/SeerOpenOCDWidget.cpp
+++ b/src/SeerOpenOCDWidget.cpp
@@ -9,10 +9,11 @@
  **********************************************************************************************************************/
 SeerOpenOCDWidget::SeerOpenOCDWidget (QWidget* parent) : SeerLogWidget(parent) {
     Q_UNUSED(parent);
-    _openocdProcess         = nullptr;
-    _gdbLiveWatchProcess    = nullptr;
-    _openocdLogsTabWidget   = nullptr;
-    _telnetSocket           = nullptr;
+    _openocdProcess             = nullptr;
+    _gdbLiveWatchProcess        = nullptr;
+    _openocdLogsTabWidget       = nullptr;
+    _openocdLogsTabWidgetParent = nullptr;
+    _telnetSocket               = nullptr;
     _liveWatchTimer         = new QTimer(this);
 }
 
@@ -72,8 +73,15 @@ void SeerOpenOCDWidget::terminate ()
         }
     }
     if (_openocdLogsTabWidget) {
+        if (_openocdLogsTabWidgetParent) {
+            int index = _openocdLogsTabWidgetParent->indexOf(_openocdLogsTabWidget);
+            if (index != -1) {
+                _openocdLogsTabWidgetParent->removeTab(index);  // Relinquishes Qt's ownership of the widget.
+            }
+        }
         delete _openocdLogsTabWidget;
         _openocdLogsTabWidget = nullptr;
+        _openocdLogsTabWidgetParent = nullptr;
     }
     terminateGdbLiveWatch();
 }
@@ -253,6 +261,7 @@ void SeerOpenOCDWidget::createOpenOCDConsole (QDetachTabWidget* parent)
         return;
     }
     _openocdLogsTabWidget = new SeerLogWidget();
+    _openocdLogsTabWidgetParent = parent;
     parent->addTab(_openocdLogsTabWidget, "OpenOCD output");
     _openocdLogsTabWidget->setPlaceholderText("[OpenOCD output]");
     _openocdLogsTabWidget->setLogEnabled(true);
@@ -265,7 +274,9 @@ SeerLogWidget* SeerOpenOCDWidget::openocdConsole()
 
 void SeerOpenOCDWidget::setConsoleVisible (bool flag)
 {
-    _openocdLogsTabWidget->setVisible(flag);
+    if (_openocdLogsTabWidget) {
+        _openocdLogsTabWidget->setVisible(flag);
+    }
 }
 
 /***********************************************************************************************************************
@@ -274,7 +285,9 @@ void SeerOpenOCDWidget::setConsoleVisible (bool flag)
 void SeerOpenOCDWidget::handleReadOutput ()
 {
     QString Text = QString::fromLocal8Bit(_openocdProcess->readAllStandardOutput());
-    _openocdLogsTabWidget->handleText(Text);
+    if (_openocdLogsTabWidget) {
+        _openocdLogsTabWidget->handleText(Text);
+    }
 }
 
 void SeerOpenOCDWidget::handleReadError ()
@@ -291,5 +304,7 @@ void SeerOpenOCDWidget::handleReadError ()
         emit openocdStartFailed();
         QMessageBox::warning(this, "Seer", "OpenOCD failed to start. \nCheck openOCD output for details.", QMessageBox::Ok);
     }
-    _openocdLogsTabWidget->handleText(Text);
+    if (_openocdLogsTabWidget) {
+        _openocdLogsTabWidget->handleText(Text);
+    }
 }

--- a/src/SeerOpenOCDWidget.h
+++ b/src/SeerOpenOCDWidget.h
@@ -5,6 +5,7 @@
 #include <QtWidgets/QWidget>
 #include <QTcpSocket>
 #include <QTimer>
+#include <QPointer>
 #include "QDetachTabWidget.h"
 #include "SeerLogWidget.h"
 /***********************************************************************************************************************
@@ -50,7 +51,8 @@ class SeerOpenOCDWidget: public SeerLogWidget{
         QProcess*                           _openocdProcess;
         QProcess*                           _gdbLiveWatchProcess;
         QTcpSocket*                         _telnetSocket;
-        SeerLogWidget*                      _openocdLogsTabWidget;
+        QPointer<SeerLogWidget>              _openocdLogsTabWidget;
+        QPointer<QDetachTabWidget>           _openocdLogsTabWidgetParent;
         QString                             _telnetPort;
         QTemporaryDir                       _tempDir;
         QTimer*                             _liveWatchTimer;


### PR DESCRIPTION
This MR resolves the issue that occurs when closing Seer while running in OpenOCD mode:
<img width="561" height="152" alt="image" src="https://github.com/user-attachments/assets/5084b367-f247-4e2f-b502-58bfb88c4ce5" />
Root cause: something elsewhere in the code was destroying _openocdLogsTabWidget, probably through normal parent-child cleanup. Bc `parent->addTab(_openocdLogsTabWidget, "OpenOCD output");` and the `parent` in this case is `_openocdWidget->createOpenOCDConsole(commandLogsWidget->logsTabWidgetInstance());`
-> the parent of `_openocdLogsTabWidget` is `commandLogsWidget->logsTabWidgetInstance`
-> So we shouldn't manually `delete _openocdLogsTabWidget` as its parent should do the clean up.
Fix:
 raw pointer has no idea when its target dies — it just keeps holding the same address
 QPointer will constantly check if the target is alive or not before deleting