### PR TITLE
Debug kernel module / kernel driver

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ if(${QTVERSION} STREQUAL "QT6")
     find_package(Qt6 COMPONENTS REQUIRED Svg)
     find_package(Qt6 COMPONENTS REQUIRED OpenGL)
     find_package(Qt6 COMPONENTS REQUIRED Network)
+    find_package(Qt6 COMPONENTS REQUIRED SerialPort)
 
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -167,6 +168,7 @@ set(HEADER_FILES
     SeerMacroToolButton.h
     SeerOpenOCDWidget.h
     SeerOpenocdConfigPage.h
+    SeerOpenOCDDebugOnInit.h
     )
 
 # Define the source location of source files
@@ -283,6 +285,7 @@ set(SOURCE_FILES
     SeerMacroToolButton.cpp
     SeerOpenOCDWidget.cpp
     SeerOpenocdConfigPage.cpp
+    SeerOpenOCDDebugOnInit.cpp
     seergdb.cpp
     )
 
@@ -313,7 +316,7 @@ add_executable(${PROJECT_NAME} ${SYSTEM_TYPE} ${SOURCE_FILES})
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 
 if(${QTVERSION} STREQUAL "QT6")
-    target_link_libraries(${PROJECT_NAME} Qt6::Widgets Qt6::Gui Qt6::Core Qt6::PrintSupport Qt6::Charts Qt6::Svg Qt6::OpenGL Qt6::Network)
+    target_link_libraries(${PROJECT_NAME} Qt6::Widgets Qt6::Gui Qt6::Core Qt6::PrintSupport Qt6::Charts Qt6::Svg Qt6::OpenGL Qt6::Network Qt6::SerialPort)
 elseif(${QTVERSION} STREQUAL "QT5")
     target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::Gui Qt5::Core Qt5::PrintSupport Qt5::Charts)
 endif()

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -31,6 +31,7 @@
 #include <QtCore/QFileInfoList>
 #include <QtCore/QThread>
 #include <QtCore/QDebug>
+#include <QTimer>
 #include <QtGlobal>
 #include <unistd.h>
 #include <stdlib.h>
@@ -55,6 +56,9 @@ SeerGdbWidget::SeerGdbWidget (QWidget* parent) : QWidget(parent) {
     _executableRRTraceDirectory             = "";
     _executableCoreFilename                 = "";
     _executablePid                          = 0;
+
+    // Openocd Debug On Init
+    _debugOnInitFlag                        = false;
 
     _gdbMonitor                             = 0;
     _gdbProcess                             = 0;
@@ -798,6 +802,11 @@ void SeerGdbWidget::handleText (const QString& text) {
         _openocdRunningState = "stopped";
         emit stoppingPointReached();
 
+        // A Debug on Init run was waiting for the target to stop before starting - go now.
+        if (isDebugOnInit() == true) {
+            firePendingDebugOnInitCommand();
+        }
+
     }else if (text.startsWith("=breakpoint-created,")) {
 
         handleGdbGenericpointList();
@@ -820,13 +829,35 @@ void SeerGdbWidget::handleText (const QString& text) {
 
         handleGdbSignalListValues("all");
 
+    // MIDebugOnInit.py emits '@debug-on-init-complete <ok|error> <detail>' when the -debug-on-init
+    // sequence finishes (success or failure).
+    }else if (text.contains("@debug-on-init-complete")) {
+
+        setDebugOnInitFlag(false);
+
+        QString detail = text.section("@debug-on-init-complete", 1);
+        detail.replace("\\n", " ").replace("\\\"", "\"").remove('"').replace("\\t", " ");
+        detail = detail.trimmed();
+
+        bool ok = detail.startsWith("ok");
+        detail.remove(0, ok ? 2 : 5);            // strip the "ok"/"error" keyword
+        detail = detail.trimmed();
+
+        if (ok) {
+            QMessageBox::information(this, "Seer", detail.isEmpty()
+                                     ? QString("Debug on Init complete.")
+                                     : QString("Debug on Init complete.\n\n%1").arg(detail));
+        }else{
+            QMessageBox::warning(this, "Seer", QString("Debug on Init failed.\n\n%1").arg(detail));
+        }
+
+        // Bring Seer's views back in sync with wherever the target ended up stopped.
+        emit stoppingPointReached();
+        handleGdbGenericpointList();
+
     }else{
         // All other text is ignored by this widget.
     }
-}
-
-void SeerGdbWidget::handleTextDebugOnInit (const QString& text) {
-        qCDebug(LC) << "DebugOnInit: " << text;
 }
 
 void SeerGdbWidget::handleManualCommandExecute (QString command) {
@@ -4252,12 +4283,18 @@ void SeerGdbWidget::handleGdbMultiarchOpenOCDExecutable ()
  * Start of handle Debug On Init
  **********************************************************************************************************************/
 void SeerGdbWidget::handleDebugOnInit () {
+
+    if (isDebugOnInit() == true) {
+        QMessageBox::warning(nullptr, "Seer", QString("A Debug on Init sequence is already running."), QMessageBox::Ok);
+        return;
+    }
+
     // Promtp a dialog, tell user to input kernel module that they want to debug
     SeerOpenOCDDebugOnInit dlg(this);
     int ret = dlg.exec();
     if (ret == 0)
         return;
-    
+
     _moduleName                 = dlg.moduleName();
     _commandToTerm              = dlg.commandToTerm();
     _kernelModuleSymbolPath     = dlg.kernelModuleSymbolPath();
@@ -4287,14 +4324,56 @@ void SeerGdbWidget::handleDebugOnInit () {
         return;
     }
 
-    // Disconnect all signals from _gdbMonitor to this, SeerGdbWidget::handleText
-    QObject::disconnect(_gdbMonitor, &GdbMonitor::astrixTextOutput, this, &SeerGdbWidget::handleText);
-    QObject::disconnect(_gdbMonitor, &GdbMonitor::equalTextOutput,  this, &SeerGdbWidget::handleText);
-    QObject::disconnect(_gdbMonitor, &GdbMonitor::tildeTextOutput,  this, &SeerGdbWidget::handleText);
+    // The whole sequence runs inside gdb, driven by the -debug-on-init Python MI command
+    // (resources/mi-python/MIDebugOnInit.py). It runs synchronously there (mi-async off, blocking
+    // 'continue'), so there are no MI-async races to orchestrate around from here - Seer just
+    // fires the command and waits for the '@debug-on-init-complete' console line (or an ^error).
+    setDebugOnInitFlag(true);
 
-    // Instead, connect _gdbMonitor signal to SeerGdbWidget::handleTextDebugOnInit
-    QObject::connect(_gdbMonitor, &GdbMonitor::astrixTextOutput, this, &SeerGdbWidget::handleTextDebugOnInit);
-    QObject::connect(_gdbMonitor, &GdbMonitor::equalTextOutput,  this, &SeerGdbWidget::handleTextDebugOnInit);
-    QObject::connect(_gdbMonitor, &GdbMonitor::tildeTextOutput,  this, &SeerGdbWidget::handleTextDebugOnInit);
-    // Checkpoint
+    auto quote = [](const QString& s) { QString q = s; q.replace("\\", "\\\\").replace("\"", "\\\""); return QString("\"") + q + "\""; };
+
+    _debugOnInitPendingCommand = "-debug-on-init "
+                               + quote(_moduleName)                 + " "
+                               + quote(_serialPortPath)             + " "
+                               + quote(_kernelModuleSymbolPath)     + " "
+                               + quote(_kernelModuleSourceCodePath) + " "
+                               + quote(_commandToTerm);
+
+    // The Python command needs the target stopped ('set mi-async off' fails while it runs), and a
+    // Python MI command can't wait for a stop itself (gdb's event loop doesn't run inside invoke()).
+    // So do the stop here: unless we know it's already stopped, SIGINT and fire the command from
+    // handleText() on the *stopped. The timer is a fallback for when no *stopped arrives (it was
+    // already stopped) - firePendingDebugOnInitCommand() only sends once.
+    if (_openocdRunningState == "stopped") {
+        firePendingDebugOnInitCommand();
+    }else{
+        handleGdbInterruptSIGINT();
+    }
+
+    QTimer::singleShot(2000, this, [this]() { firePendingDebugOnInitCommand(); });
+}
+
+// Sends the queued '-debug-on-init ...' command once (whichever of handleText()/the fallback timer
+// gets here first); a no-op afterwards.
+void SeerGdbWidget::firePendingDebugOnInitCommand () {
+
+    if (_debugOnInitPendingCommand.isEmpty()) {
+        return;
+    }
+
+    QString command = _debugOnInitPendingCommand;
+    _debugOnInitPendingCommand.clear();
+
+    handleGdbCommand(command);
+}
+
+/***********************************************************************************************************************
+ * Openocd Debug On Init                                                                                               *
+ **********************************************************************************************************************/
+void SeerGdbWidget::setDebugOnInitFlag (bool flag) {
+    _debugOnInitFlag = flag;
+}
+
+bool SeerGdbWidget::isDebugOnInit () {
+    return _debugOnInitFlag;
 }

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -4242,3 +4242,10 @@ void SeerGdbWidget::handleGdbMultiarchOpenOCDExecutable ()
 
     qCDebug(LC) << "Finishing 'gdb-multiarch connect'.";
 }
+
+/***********************************************************************************************************************
+ * Start of handle Debug On Init
+ **********************************************************************************************************************/
+void SeerGdbWidget::handleDebugOnInit () {
+
+}

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -15,6 +15,7 @@
 #include "SeerUtl.h"
 #include "QHContainerWidget.h"
 #include "SeerOpenOCDWidget.h"
+#include "SeerOpenOCDDebugOnInit.h"
 #include <QtGui/QFont>
 #include <QtGui/QGuiApplication>
 #include <QtWidgets/QApplication>
@@ -822,6 +823,10 @@ void SeerGdbWidget::handleText (const QString& text) {
     }else{
         // All other text is ignored by this widget.
     }
+}
+
+void SeerGdbWidget::handleTextDebugOnInit (const QString& text) {
+        qCDebug(LC) << "DebugOnInit: " << text;
 }
 
 void SeerGdbWidget::handleManualCommandExecute (QString command) {
@@ -4247,5 +4252,49 @@ void SeerGdbWidget::handleGdbMultiarchOpenOCDExecutable ()
  * Start of handle Debug On Init
  **********************************************************************************************************************/
 void SeerGdbWidget::handleDebugOnInit () {
+    // Promtp a dialog, tell user to input kernel module that they want to debug
+    SeerOpenOCDDebugOnInit dlg(this);
+    int ret = dlg.exec();
+    if (ret == 0)
+        return;
+    
+    _moduleName                 = dlg.moduleName();
+    _commandToTerm              = dlg.commandToTerm();
+    _kernelModuleSymbolPath     = dlg.kernelModuleSymbolPath();
+    _kernelModuleSourceCodePath = dlg.kernelModuleSourceCodePath();
+    _serialPortPath             = dlg.serialPortPath();
 
+    // Checkpoint
+    if (_kernelModuleSymbolPath == "")
+    {
+        QMessageBox::warning(nullptr, "Seer", QString("Path to kernel module symbol is empty. Abort!"), QMessageBox::Ok);
+        return;
+    }
+    if (_kernelModuleSourceCodePath == "")
+    {
+        QMessageBox::warning(nullptr, "Seer", QString("Path to kernel module source code is empty. Abort!"), QMessageBox::Ok);
+        return;
+    }
+    if ( Seer::isFileExistNotify(_kernelModuleSymbolPath) == false)
+        return;
+    if ( Seer::isDirExistNotify(_kernelModuleSourceCodePath) == false)
+        return;
+    if ( Seer::isFileExistNotify(_serialPortPath) == false)
+        return;
+    if (_moduleName == "" || _commandToTerm == "")
+    {
+        QMessageBox::warning(nullptr, "Seer", QString("Command to terminal is empty. Abort!"), QMessageBox::Ok);
+        return;
+    }
+
+    // Disconnect all signals from _gdbMonitor to this, SeerGdbWidget::handleText
+    QObject::disconnect(_gdbMonitor, &GdbMonitor::astrixTextOutput, this, &SeerGdbWidget::handleText);
+    QObject::disconnect(_gdbMonitor, &GdbMonitor::equalTextOutput,  this, &SeerGdbWidget::handleText);
+    QObject::disconnect(_gdbMonitor, &GdbMonitor::tildeTextOutput,  this, &SeerGdbWidget::handleText);
+
+    // Instead, connect _gdbMonitor signal to SeerGdbWidget::handleTextDebugOnInit
+    QObject::connect(_gdbMonitor, &GdbMonitor::astrixTextOutput, this, &SeerGdbWidget::handleTextDebugOnInit);
+    QObject::connect(_gdbMonitor, &GdbMonitor::equalTextOutput,  this, &SeerGdbWidget::handleTextDebugOnInit);
+    QObject::connect(_gdbMonitor, &GdbMonitor::tildeTextOutput,  this, &SeerGdbWidget::handleTextDebugOnInit);
+    // Checkpoint
 }

--- a/src/SeerGdbWidget.cpp
+++ b/src/SeerGdbWidget.cpp
@@ -829,6 +829,18 @@ void SeerGdbWidget::handleText (const QString& text) {
 
         handleGdbSignalListValues("all");
 
+    // MIDebugOnInit.py emits '@debug-on-init-warning <detail>' for a non-fatal notice while the
+    // sequence is still running (e.g. it couldn't write the load command to the serial port itself -
+    // permission denied - so the user needs to type it manually on the target). Unlike
+    // '@debug-on-init-complete' below, this does NOT clear _debugOnInitFlag: the sequence is still
+    // in progress, waiting on the breakpoint.
+    }else if (text.contains("@debug-on-init-warning")) {
+
+        QString detail = text.section("@debug-on-init-warning", 1);
+        detail.replace("\\n", " ").replace("\\\"", "\"").remove('"').replace("\\t", " ");
+        detail = detail.trimmed();
+        QMessageBox::warning(this, "Seer", QString("Debug on Init needs your help.\n\n%1").arg(detail));
+
     // MIDebugOnInit.py emits '@debug-on-init-complete <ok|error> <detail>' when the -debug-on-init
     // sequence finishes (success or failure).
     }else if (text.contains("@debug-on-init-complete")) {

--- a/src/SeerGdbWidget.h
+++ b/src/SeerGdbWidget.h
@@ -244,6 +244,7 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
 
     public slots:
         void                                handleText                                  (const QString& text);
+        void                                handleTextDebugOnInit                       (const QString& text);
         void                                handleManualCommandExecute                  (QString command);
         void                                handleGdbCommand                            (const QString& command, bool ignoreErrors=false);
         void                                handleGdbCommands                           (const QStringList& commands);
@@ -496,5 +497,12 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
         QString                             _loadAddress;
         QString                             _symbolFile;
         QString                             _sourcePath;
+
+        // Openocd Debug On Init
+        QString                             _moduleName;
+        QString                             _commandToTerm;
+        QString                             _kernelModuleSymbolPath;
+        QString                             _kernelModuleSourceCodePath;
+        QString                             _serialPortPath;
 };
 

--- a/src/SeerGdbWidget.h
+++ b/src/SeerGdbWidget.h
@@ -404,6 +404,7 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
         void                                handleGdbProcessErrored                     (QProcess::ProcessError errorStatus);
 
         void                                handleAboutToQuit                           ();
+        void                                handleDebugOnInit                           ();
 
     signals:
         void                                stoppingPointReached                        ();

--- a/src/SeerGdbWidget.h
+++ b/src/SeerGdbWidget.h
@@ -242,9 +242,14 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
 
         void                                handleGdbMultiarchOpenOCDExecutable         ();
 
+        // Openocd Debug On Init: the whole sequence runs inside gdb via the '-debug-on-init' Python
+        // MI command (resources/mi-python/MIDebugOnInit.py). These just track whether a run is in
+        // progress.
+        void                                setDebugOnInitFlag                          (bool flag);
+        bool                                isDebugOnInit                               ();
+
     public slots:
         void                                handleText                                  (const QString& text);
-        void                                handleTextDebugOnInit                       (const QString& text);
         void                                handleManualCommandExecute                  (QString command);
         void                                handleGdbCommand                            (const QString& command, bool ignoreErrors=false);
         void                                handleGdbCommands                           (const QStringList& commands);
@@ -406,6 +411,7 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
 
         void                                handleAboutToQuit                           ();
         void                                handleDebugOnInit                           ();
+        void                                firePendingDebugOnInitCommand               ();
 
     signals:
         void                                stoppingPointReached                        ();
@@ -504,5 +510,8 @@ class SeerGdbWidget : public QWidget, protected Ui::SeerGdbWidgetForm {
         QString                             _kernelModuleSymbolPath;
         QString                             _kernelModuleSourceCodePath;
         QString                             _serialPortPath;
+
+        bool                                _debugOnInitFlag;               // A debug-on-init sequence is in progress.
+        QString                             _debugOnInitPendingCommand;     // The '-debug-on-init ...' MI command, held until the target is stopped (fired from handleText() on the *stopped).
 };
 

--- a/src/SeerMainWindow.cpp
+++ b/src/SeerMainWindow.cpp
@@ -111,6 +111,9 @@ SeerMainWindow::SeerMainWindow(QWidget* parent) : QMainWindow(parent) {
     actionGdbStepi->setVisible(false);
     actionGdbFinish->setVisible(true);
 
+    // OpenOCD disable Debug On Init by default
+    actionDebugOnInit->setVisible(false);
+
     // Set up Interrupt menu.
     QMenu* menuInterrupt = new QMenu(this);
     _interruptAction = menuInterrupt->addAction("Interrupt");
@@ -188,6 +191,7 @@ SeerMainWindow::SeerMainWindow(QWidget* parent) : QMainWindow(parent) {
     QObject::connect(actionControlRecordReverse,        &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbRecordReverse);
     QObject::connect(actionControlRecordStop,           &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbRecordStop);
     QObject::connect(actionControlInterrupt,            &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleGdbInterrupt);
+    QObject::connect(actionDebugOnInit,                 &QAction::triggered,                            gdbWidget,                      &SeerGdbWidget::handleDebugOnInit);
 
     QObject::connect(actionSettingsConfiguration,       &QAction::triggered,                            this,                           &SeerMainWindow::handleSettingsConfiguration);
     QObject::connect(actionSettingsSaveConfiguration,   &QAction::triggered,                            this,                           &SeerMainWindow::handleSettingsSaveConfiguration);
@@ -502,6 +506,7 @@ void SeerMainWindow::launchExecutable (const QString& launchMode, const QString&
     actionControlRestart->setVisible(true);
     actionControlTerminate->setVisible(true);
     actionControlInterrupt->setVisible(true);
+    actionDebugOnInit->setVisible(false);
 
     if (launchMode == "run") {
 
@@ -545,6 +550,7 @@ void SeerMainWindow::launchExecutable (const QString& launchMode, const QString&
         actionGdbStepi->setVisible(false);
         actionControlNexti->setVisible(false);
         actionControlStepi->setVisible(false);
+        actionDebugOnInit->setVisible(true);
         // launch gdb-multiarch and openocd
         gdbWidget->handleGdbMultiarchOpenOCDExecutable();
 
@@ -1088,6 +1094,7 @@ void SeerMainWindow::handleRestartExecutable () {
         actionGdbStepi->setVisible(false);
         actionControlNexti->setVisible(false);
         actionControlStepi->setVisible(false);
+        actionDebugOnInit->setVisible(true);
         gdbWidget->handleGdbMultiarchOpenOCDExecutable();
 
     }
@@ -1207,6 +1214,7 @@ void SeerMainWindow::handleGdbStateChanged () {
         actionGdbTerminate->setVisible(false);
         actionControlRestart->setVisible(true);
         actionControlTerminate->setVisible(true);
+        actionDebugOnInit->setVisible(false);
 
         // Get the hotkey for the Restart button.
         QString hotkey = "";

--- a/src/SeerMainWindow.ui
+++ b/src/SeerMainWindow.ui
@@ -203,6 +203,8 @@
    <addaction name="actionInterruptProcess"/>
    <addaction name="separator"/>
    <addaction name="actionVisualizers"/>
+   <addaction name="separator"/>
+   <addaction name="actionDebugOnInit"/>
   </widget>
   <action name="actionFileQuit">
    <property name="icon">
@@ -831,6 +833,15 @@
    </property>
    <property name="text">
     <string>GDB Monitor</string>
+   </property>
+  </action>
+  <action name="actionDebugOnInit">
+   <property name="icon">
+    <iconset resource="resource.qrc">
+     <normaloff>:/seer/resources/icons-icons/debug.png</normaloff>:/seer/resources/icons-icons/debug.png</iconset>
+   </property>
+   <property name="text">
+    <string>Debug On Init</string>
    </property>
   </action>
  </widget>

--- a/src/SeerOpenOCDDebugOnInit.cpp
+++ b/src/SeerOpenOCDDebugOnInit.cpp
@@ -1,0 +1,132 @@
+#include "SeerOpenOCDDebugOnInit.h"
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QToolButton>
+#include <QLineEdit>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QSerialPortInfo>
+
+SeerOpenOCDDebugOnInit::SeerOpenOCDDebugOnInit (QWidget* parent) : QDialog(parent) {
+
+    // Set up the UI.
+    setupUi(this);
+
+    // Connect signal and slots
+    QObject::connect(kernelModuleSymbolButton,          &QToolButton::clicked,          this,           &SeerOpenOCDDebugOnInit::handleKernelModuleSymbolButton);
+    QObject::connect(kernelModuleSourceCodeButton,      &QToolButton::clicked,          this,           &SeerOpenOCDDebugOnInit::handleKernelModuleSourceCodeButton);
+    QObject::connect(moduleNameLineEdit,                &QLineEdit::textChanged,        [&](const QString &text){   commandLineEdit->setText("insmod " + text + ".ko");   });
+    QObject::connect(buttonBox,                         &QDialogButtonBox::accepted,    this,           &SeerOpenOCDDebugOnInit::onAccepted);
+    QObject::connect(serialComboBox,                    &QComboBox::currentTextChanged, this,           &SeerOpenOCDDebugOnInit::handleComboBoxTextChanged);
+    
+    _moduleName                     = "";
+    _commandToTerm                  = "insmod ";;
+    _kernelModuleSymbolPath         = "";
+    _kernelModuleSourceCodePath     = "";
+    _serialPortPath                 = "";
+
+    const auto ports = QSerialPortInfo::availablePorts();
+
+    for (const QSerialPortInfo &port : ports)
+    {
+        if (port.portName().contains("ttyUSB"))
+        {
+            serialComboBox->addItem(QString(port.systemLocation()));
+        }
+    }
+
+    for (const QSerialPortInfo &port : ports)
+    {
+        if (!port.portName().contains("ttyUSB"))
+            serialComboBox->addItem(QString(port.systemLocation()));
+    }
+    
+}
+
+SeerOpenOCDDebugOnInit::~SeerOpenOCDDebugOnInit () {
+}
+
+/***********************************************************************************************************************
+ * Getter and setter
+ **********************************************************************************************************************/
+void SeerOpenOCDDebugOnInit::setModuleName (const QString& name)
+{
+    _moduleName = name;
+}
+
+const QString SeerOpenOCDDebugOnInit::moduleName ()
+{
+    return _moduleName;
+}
+
+void SeerOpenOCDDebugOnInit::setCommandToTerm (const QString& command)
+{
+    _commandToTerm = command;
+}
+
+const QString SeerOpenOCDDebugOnInit::commandToTerm ()
+{
+    return _commandToTerm;
+}
+
+void SeerOpenOCDDebugOnInit::setkernelModuleSymbolPath (const QString& path)
+{
+    _kernelModuleSymbolPath = path;
+}
+
+const QString SeerOpenOCDDebugOnInit::kernelModuleSymbolPath ()
+{
+    return _kernelModuleSymbolPath;
+}
+
+void SeerOpenOCDDebugOnInit::setKernelModuleSourceCodePath (const QString& path)
+{
+    _kernelModuleSourceCodePath = path;
+}
+
+const QString SeerOpenOCDDebugOnInit::kernelModuleSourceCodePath ()
+{
+    return _kernelModuleSourceCodePath;
+}
+
+void SeerOpenOCDDebugOnInit::setSerialPortPath (const QString& path)
+{
+    _serialPortPath = path;
+}
+
+const QString SeerOpenOCDDebugOnInit::serialPortPath()
+{
+    return _serialPortPath;
+}
+/***********************************************************************************************************************
+ * Slot handling open file / folder
+ **********************************************************************************************************************/
+void SeerOpenOCDDebugOnInit::handleKernelModuleSymbolButton () {
+    QString name = QFileDialog::getOpenFileName(this, "Selec Kernel Module Symbol.", kernelModuleSymbolPath(), "", nullptr, QFileDialog::DontUseNativeDialog);
+
+    if (name != "") {
+        setkernelModuleSymbolPath(name);
+        kernelModuleSymbolLineEdit->setText(kernelModuleSymbolPath());
+    }
+}
+
+void SeerOpenOCDDebugOnInit::handleKernelModuleSourceCodeButton () {
+    QString name = QFileDialog::getExistingDirectory(this, "Select kernel source code directory.", kernelModuleSourceCodePath(), QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
+
+    if (name != "") {
+        setKernelModuleSourceCodePath(name);
+        kernelModuleSourceCodeLineEdit->setText(kernelModuleSourceCodePath());
+    }
+}
+
+void SeerOpenOCDDebugOnInit::handleComboBoxTextChanged()
+{
+    setSerialPortPath(serialComboBox->currentText());
+}
+
+void SeerOpenOCDDebugOnInit::onAccepted()
+{
+    setModuleName(moduleNameLineEdit->text());
+    setCommandToTerm(commandLineEdit->text());
+    setkernelModuleSymbolPath(kernelModuleSymbolLineEdit->text());
+    setKernelModuleSourceCodePath(kernelModuleSourceCodeLineEdit->text());
+}

--- a/src/SeerOpenOCDDebugOnInit.cpp
+++ b/src/SeerOpenOCDDebugOnInit.cpp
@@ -15,7 +15,7 @@ SeerOpenOCDDebugOnInit::SeerOpenOCDDebugOnInit (QWidget* parent) : QDialog(paren
     // Connect signal and slots
     QObject::connect(kernelModuleSymbolButton,          &QToolButton::clicked,          this,           &SeerOpenOCDDebugOnInit::handleKernelModuleSymbolButton);
     QObject::connect(kernelModuleSourceCodeButton,      &QToolButton::clicked,          this,           &SeerOpenOCDDebugOnInit::handleKernelModuleSourceCodeButton);
-    QObject::connect(moduleNameLineEdit,                &QLineEdit::textChanged,        [&](const QString &text){   commandLineEdit->setText("insmod " + text + ".ko");   });
+    QObject::connect(moduleNameLineEdit,                &QLineEdit::textChanged,        [&](const QString &text){   commandLineEdit->setText("taskset -c 0 insmod " + text + ".ko");   });
     QObject::connect(buttonBox,                         &QDialogButtonBox::accepted,    this,           &SeerOpenOCDDebugOnInit::onAccepted);
     QObject::connect(serialComboBox,                    &QComboBox::currentTextChanged, this,           &SeerOpenOCDDebugOnInit::handleComboBoxTextChanged);
     

--- a/src/SeerOpenOCDDebugOnInit.cpp
+++ b/src/SeerOpenOCDDebugOnInit.cpp
@@ -5,6 +5,7 @@
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QSerialPortInfo>
+#include <QtCore/QSettings>
 
 SeerOpenOCDDebugOnInit::SeerOpenOCDDebugOnInit (QWidget* parent) : QDialog(parent) {
 
@@ -39,7 +40,8 @@ SeerOpenOCDDebugOnInit::SeerOpenOCDDebugOnInit (QWidget* parent) : QDialog(paren
         if (!port.portName().contains("ttyUSB"))
             serialComboBox->addItem(QString(port.systemLocation()));
     }
-    
+
+    readSettings();
 }
 
 SeerOpenOCDDebugOnInit::~SeerOpenOCDDebugOnInit () {
@@ -101,7 +103,7 @@ const QString SeerOpenOCDDebugOnInit::serialPortPath()
  * Slot handling open file / folder
  **********************************************************************************************************************/
 void SeerOpenOCDDebugOnInit::handleKernelModuleSymbolButton () {
-    QString name = QFileDialog::getOpenFileName(this, "Selec Kernel Module Symbol.", kernelModuleSymbolPath(), "", nullptr, QFileDialog::DontUseNativeDialog);
+    QString name = QFileDialog::getOpenFileName(this, "Select Kernel Module Symbol.", kernelModuleSymbolPath(), "", nullptr, QFileDialog::DontUseNativeDialog);
 
     if (name != "") {
         setkernelModuleSymbolPath(name);
@@ -125,8 +127,40 @@ void SeerOpenOCDDebugOnInit::handleComboBoxTextChanged()
 
 void SeerOpenOCDDebugOnInit::onAccepted()
 {
+    // Push the current text into the history (in case focus was never lost).
+    moduleNameLineEdit->execute();
+    kernelModuleSymbolLineEdit->execute();
+    kernelModuleSourceCodeLineEdit->execute();
+
     setModuleName(moduleNameLineEdit->text());
     setCommandToTerm(commandLineEdit->text());
     setkernelModuleSymbolPath(kernelModuleSymbolLineEdit->text());
     setKernelModuleSourceCodePath(kernelModuleSourceCodeLineEdit->text());
+
+    writeSettings();
+}
+
+/***********************************************************************************************************************
+ * Settings
+ **********************************************************************************************************************/
+void SeerOpenOCDDebugOnInit::readSettings () {
+
+    QSettings settings;
+
+    settings.beginGroup("openocddebuginit"); {
+        moduleNameLineEdit->setHistory(settings.value("modulenamehistory").toStringList());
+        kernelModuleSymbolLineEdit->setHistory(settings.value("kernelmodulesymbolhistory").toStringList());
+        kernelModuleSourceCodeLineEdit->setHistory(settings.value("kernelmodulesourcecodehistory").toStringList());
+    } settings.endGroup();
+}
+
+void SeerOpenOCDDebugOnInit::writeSettings () {
+
+    QSettings settings;
+
+    settings.beginGroup("openocddebuginit"); {
+        settings.setValue("modulenamehistory", moduleNameLineEdit->history());
+        settings.setValue("kernelmodulesymbolhistory", kernelModuleSymbolLineEdit->history());
+        settings.setValue("kernelmodulesourcecodehistory", kernelModuleSourceCodeLineEdit->history());
+    } settings.endGroup();
 }

--- a/src/SeerOpenOCDDebugOnInit.h
+++ b/src/SeerOpenOCDDebugOnInit.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QButtonGroup>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+
+#include "ui_SeerOpenOCDDebugOnInit.h"
+
+class SeerOpenOCDDebugOnInit : public QDialog, protected Ui::SeerOpenOCDDebugOnInit {
+
+    Q_OBJECT
+
+    public:
+        explicit SeerOpenOCDDebugOnInit (QWidget* parent = 0);
+       ~SeerOpenOCDDebugOnInit ();
+        void                    setModuleName                       (const QString& name);
+        const QString           moduleName                          ();
+        void                    setCommandToTerm                    (const QString& command);
+        const QString           commandToTerm                       ();
+        void                    setkernelModuleSymbolPath           (const QString& path);
+        const QString           kernelModuleSymbolPath              ();
+        void                    setKernelModuleSourceCodePath       (const QString& path);
+        const QString           kernelModuleSourceCodePath          ();
+        void                    setSerialPortPath                   (const QString& path);
+        const QString           serialPortPath                      ();
+
+    private slots:
+        void            handleKernelModuleSymbolButton              ();
+        void            handleKernelModuleSourceCodeButton          ();
+        void            onAccepted                                  ();
+        void            handleComboBoxTextChanged                   ();
+
+    private:
+        QString         _moduleName;
+        QString         _commandToTerm;
+        QString         _kernelModuleSymbolPath;
+        QString         _kernelModuleSourceCodePath;
+        QString         _serialPortPath;
+
+
+};
+

--- a/src/SeerOpenOCDDebugOnInit.h
+++ b/src/SeerOpenOCDDebugOnInit.h
@@ -32,6 +32,9 @@ class SeerOpenOCDDebugOnInit : public QDialog, protected Ui::SeerOpenOCDDebugOnI
         void            handleComboBoxTextChanged                   ();
 
     private:
+        void            readSettings                                ();
+        void            writeSettings                               ();
+
         QString         _moduleName;
         QString         _commandToTerm;
         QString         _kernelModuleSymbolPath;

--- a/src/SeerOpenOCDDebugOnInit.ui
+++ b/src/SeerOpenOCDDebugOnInit.ui
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SeerOpenOCDDebugOnInit</class>
+ <widget class="QDialog" name="SeerOpenOCDDebugOnInit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>603</width>
+    <height>254</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Ignored">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>254</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>254</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Module name (without .ko)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="moduleNameLineEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Send command to TERM window</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="commandLineEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_5">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Serial Port</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="serialComboBox"/>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout_5">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
+     <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Path to kernel module symbol file (.ko)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLineEdit" name="kernelModuleSymbolLineEdit"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="kernelModuleSymbolButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>24</width>
+             <height>23</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>24</width>
+             <height>23</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="resource.qrc">
+             <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Path to kernel module source code</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLineEdit" name="kernelModuleSourceCodeLineEdit"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="kernelModuleSourceCodeButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>24</width>
+             <height>23</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>24</width>
+             <height>23</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="resource.qrc">
+             <normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</normaloff>:/seer/resources/RelaxLightIcons/document-open.svg</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="resource.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SeerOpenOCDDebugOnInit</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SeerOpenOCDDebugOnInit</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/SeerOpenOCDDebugOnInit.ui
+++ b/src/SeerOpenOCDDebugOnInit.ui
@@ -53,12 +53,15 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="moduleNameLineEdit">
+        <widget class="SeerHistoryLineEdit" name="moduleNameLineEdit">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Scroll (mouse wheel or Up/Down arrows) to cycle through previously entered module names.</string>
          </property>
         </widget>
        </item>
@@ -142,7 +145,11 @@
        <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QLineEdit" name="kernelModuleSymbolLineEdit"/>
+          <widget class="SeerHistoryLineEdit" name="kernelModuleSymbolLineEdit">
+           <property name="toolTip">
+            <string>Scroll (mouse wheel or Up/Down arrows) to cycle through previously used paths.</string>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="kernelModuleSymbolButton">
@@ -195,7 +202,11 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QLineEdit" name="kernelModuleSourceCodeLineEdit"/>
+          <widget class="SeerHistoryLineEdit" name="kernelModuleSourceCodeLineEdit">
+           <property name="toolTip">
+            <string>Scroll (mouse wheel or Up/Down arrows) to cycle through previously used paths.</string>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="kernelModuleSourceCodeButton">
@@ -244,6 +255,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SeerHistoryLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header location="global">SeerHistoryLineEdit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="resource.qrc"/>
  </resources>

--- a/src/resource.qrc
+++ b/src/resource.qrc
@@ -99,6 +99,7 @@
     <file>resources/mi-python/MIStart.py</file>
     <file>resources/mi-python/MIMonitor.py</file>
     <file>resources/mi-python/MIlsmod.py</file>
+    <file>resources/mi-python/MIDebugOnInit.py</file>
   </qresource>
 </RCC>
 

--- a/src/resource.qrc
+++ b/src/resource.qrc
@@ -98,6 +98,7 @@
     <file>resources/help/OpenOCDHelp.md</file>
     <file>resources/mi-python/MIStart.py</file>
     <file>resources/mi-python/MIMonitor.py</file>
+    <file>resources/mi-python/MIlsmod.py</file>
   </qresource>
 </RCC>
 

--- a/src/resources/help/OpenOCDHelp.md
+++ b/src/resources/help/OpenOCDHelp.md
@@ -1,1 +1,195 @@
-Test
+## OpenOCD debug mode
+
+### Introduction
+
+This mode lets Seer debug a target over JTAG/SWD via [OpenOCD](https://openocd.org), instead of a
+local process or a gdbserver. Seer starts (or connects to) `openocd`, then attaches gdb to it as a
+remote target. This is the mode used for bare-metal and Linux-kernel debugging on embedded boards
+(e.g. Raspberry Pi 4 / BCM2711) using a JTAG adapter.
+
+### Requirements
+
+In this mode, Seer needs:
+
+* Path to the `openocd` executable, e.g. `/usr/local/bin/openocd`
+* OpenOCD options/arguments (board/target `.cfg` file, adapter speed, transport, etc.), e.g.:
+  ```
+  -f board/rpi4b.cfg
+  ```
+  or, with SMP enabled (see "Multi-core (SMP) targets" below):
+  ```
+  -c "set USE_SMP 1" -f board/rpi4b.cfg
+  ```
+* Optional executable/symbol file if not already loaded, e.g. a `vmlinux` with debug info for
+  kernel debugging
+* Optional source directory, e.g. the kernel source tree the `vmlinux` was built from
+* Optional load address, if the symbol file needs one
+* gdb executable capable of talking to the target's architecture, e.g. `gdb-multiarch` for an
+  aarch64 target debugged from an x86_64 host
+* OpenOCD's gdb port (default `3333`) and telnet port (default `4444`)
+
+Example full command line Seer ends up running for a Raspberry Pi 4:
+
+```
+openocd -f board/rpi4b.cfg -c "gdb_port 3333" -c "telnet_port 4444"
+```
+
+### What can you do?
+
+Once connected, you debug as normal: set breakpoints, step, inspect memory/registers. Two things
+are specific to this mode:
+
+* **Hardware breakpoints only.** Kernel/module `.text` on most Linux targets is mapped read-only,
+  so software breakpoints (which patch the instruction stream) are unreliable there. Always use
+  `hbreak`/`thbreak`, never `break`/`tbreak`, when debugging kernel code through OpenOCD. Example:
+  ```
+  (gdb) hbreak load_module
+  Hardware assisted breakpoint 1 at 0xffffffc0080d4ed0: file kernel/module.c, line 3521.
+  ```
+* **Debug on Init.** For debugging a *loadable kernel module* from the moment it's inserted
+  (`insmod`), use the "Debug on Init" dialog:
+
+  | Field | Example value |
+  |---|---|
+  | Module name | `helloworld` |
+  | Serial device | `/dev/ttyUSB0` |
+  | Module symbol file (`.ko` with debug info) | `.../helloworld_owrt/helloworld.ko` |
+  | Kernel source directory | `.../linux-5.15.132/` |
+  | Command to load the module | `insmod helloworld.ko` (auto-filled from the module name; edit it if you need `taskset`, see below) |
+
+  Seer arms a breakpoint inside `load_module()`, sends the load command over the target's serial
+  console, waits for the stop, reads the module's real (randomized) section addresses from the
+  kernel's `mod->sect_attrs`, loads the module's symbols at those addresses with `add-symbol-file`,
+  and sets a breakpoint at the module's init function (`helloworld_init` in this example). See
+  `src/resources/mi-python/MIDebugOnInit.py`.
+
+### Multi-core (SMP) targets
+
+On a multi-core target (e.g. a 4-core Cortex-A72 board like the BCM2711 on a Raspberry Pi 4), a
+hardware breakpoint set by gdb is inserted **only on the single OpenOCD target that's currently
+selected** unless the board's OpenOCD config groups the cores together with `target smp`. Most
+stock board `.cfg` files (e.g. `target/bcm2711.cfg`) gate this behind a `USE_SMP` Tcl variable that
+**defaults to off**:
+
+```tcl
+if { [info exists USE_SMP] } {
+    set _USE_SMP $USE_SMP
+} else {
+    set _USE_SMP 0        ;# <- off unless you set it yourself
+}
+...
+if {$_USE_SMP} {
+    eval $_smp_command    ;# only now does "target smp cpu0 cpu1 cpu2 cpu3" run
+}
+```
+
+If it's off and the code you're trying to catch (e.g. `load_module()` during `insmod`, or a
+syscall/sysfs handler inside your module) happens to run on a different core than the one gdb is
+attached to, the breakpoint is silently never hit — this looks exactly like a flaky/unreliable
+breakpoint, but it isn't; the code just ran on a core that never had the breakpoint installed, and
+the target simply goes back to idle once the code finishes.
+
+**How to confirm this is what's happening:** connect to OpenOCD's telnet console (default port
+`4444`, e.g. `telnet localhost 4444`) while the breakpoint is armed, and list breakpoints per core
+(`bp` always reports on whichever target is currently selected, so select each core in turn):
+
+```
+> targets bcm2711.cpu0
+> bp
+Hardware breakpoint(IVA): addr=0xffffffc0080d6a70, len=0x4, num=1
+> targets bcm2711.cpu1
+> bp
+> targets bcm2711.cpu2
+> bp
+> targets bcm2711.cpu3
+> bp
+```
+
+Here only `cpu0` lists the breakpoint's address — `cpu1`/`cpu2`/`cpu3` print nothing at all. That's
+the confirmation: the breakpoint exists on exactly one of the four cores, so it only fires when the
+Linux scheduler happens to run the target code on that specific core.
+
+Two ways to deal with this, with different trade-offs:
+
+* **Pin the caller with `taskset` (recommended default).** If the code you're breaking on runs
+  synchronously inside a userspace process/syscall you control, run that process with
+  `taskset -c 0 <command>` to hard-pin it to the same core the breakpoint is armed on (core 0,
+  OpenOCD's default selected target — `taskset` sets a *hard* CPU affinity, so the scheduler can't
+  move the process even across a blocking syscall). This needs no board-specific setup and has no
+  crash risk, but only works for code reachable synchronously from a process you can pin — not
+  interrupt handlers, workqueues, kthreads, or a bug that only reproduces with genuine multi-core
+  parallelism. Examples, all pinned to core 0 to match a breakpoint armed on `cpu0`:
+  ```bash
+  # Loading the module (this is what Debug on Init's "Command" field sends over serial):
+  taskset -c 0 insmod helloworld.ko
+
+  # Unloading it - breakpoint on helloworld_exit():
+  taskset -c 0 rmmod helloworld
+
+  # A sysfs file the module exposes - breakpoint on fibonacci_show()/fibonacci_store():
+  taskset -c 0 cat /sys/kernel/helloworld/fibonacci
+  taskset -c 0 bash -c 'echo 10 > /sys/kernel/helloworld/fibonacci'
+  ```
+  Note the last example: `echo N > file` redirection is performed by the *current shell*, not by
+  `echo` itself, so `taskset -c 0 echo N > file` would only pin the (irrelevant) `echo` builtin.
+  Wrap it in `bash -c '...'` so the process actually doing the `open()`/`write()` is the one that's
+  pinned.
+* **Enable `target smp` in the board's OpenOCD config** (e.g. set `USE_SMP 1` before the board
+  `.cfg` is sourced):
+  ```
+  openocd -c "set USE_SMP 1" -f board/rpi4b.cfg
+  ```
+  This correctly fans a hardware breakpoint out to every core in the group (confirmed in OpenOCD's
+  own source, `src/target/breakpoints.c`, `breakpoint_add()`), so it's hit no matter which core runs
+  the code — no `taskset` needed anywhere. The trade-off: OpenOCD cross-halts *every* core in the
+  group whenever any one of them stops (a manual halt or a breakpoint hit), via the board's
+  Cross-Trigger Interface (CTI). Freezing every core for the duration of a debug session can trip
+  the target board's **hardware watchdog** — a silicon-level timer chip, unrelated to the Linux
+  kernel. This is a real, observed failure mode, not a theoretical one: on a Raspberry Pi
+  4/OpenWrt test target, enabling SMP caused the board to hard-reset a few seconds after any halt,
+  because OpenWrt's `procd` runs a `watchdogd` process that pets the BCM2835 hardware watchdog —
+  and that process is itself frozen along with every other core while the debugger has the target
+  halted:
+  ```
+  $ dmesg | grep -i watchdog
+  [    0.470921] bcm2835-wdt bcm2835-wdt: Broadcom BCM2835 watchdog timer
+  $ ps | grep watchdog
+     65 root         0 SW   [watchdogd]
+  ```
+  Kernel cmdline flags like `nowatchdog`, `nosoftlockup`, or `rcupdate.rcu_cpu_stall_suppress=1`
+  do **not** fix this — those only affect Linux's own software lockup/stall detectors, which may not
+  even be compiled into the kernel (confirmed here: `dmesg` reported `nowatchdog`/`nosoftlockup` as
+  *"Unknown kernel command line parameters"*, i.e. `CONFIG_LOCKUP_DETECTOR` wasn't built). The reset
+  comes from the separate hardware watchdog chip counting down regardless of what the Linux kernel
+  is configured to do.
+
+  If you use `target smp`, disable (or extend the timeout of) the target's hardware watchdog
+  *before* starting the debug session. How to do this is entirely board/OS-specific:
+  ```bash
+  # OpenWrt (procd):
+  kill $(pidof watchdogd)
+
+  # If the watchdog driver doesn't allow a plain close to disarm it (CONFIG_WATCHDOG_NOWAYOUT),
+  # send the magic-close character first:
+  python3 -c "
+  import os
+  fd = os.open('/dev/watchdog', os.O_WRONLY)
+  os.write(fd, b'V')
+  os.close(fd)
+  "
+
+  # systemd-based target:
+  systemctl stop watchdog
+  ```
+  Some boards have no hardware watchdog at all, in which case none of this applies. Seer does not
+  attempt to detect or disable a target's watchdog for you — this is left to your board's setup
+  documentation/scripts, since watchdog presence, register layout, and the daemon managing it are
+  entirely target-specific.
+
+### References
+
+* [OpenOCD User's Guide](https://openocd.org/doc/html/index.html)
+* [OpenOCD SMP / multi-core debugging](https://openocd.org/doc/html/Architecture-and-Core-Commands.html)
+* Your board's OpenOCD target `.cfg` file, for its `USE_SMP` (or equivalent) setting
+* Your board's watchdog hardware and the OS/init system that pets it (if you plan to use
+  `target smp`)

--- a/src/resources/help/OpenOCDHelp.md
+++ b/src/resources/help/OpenOCDHelp.md
@@ -186,6 +186,52 @@ Two ways to deal with this, with different trade-offs:
   documentation/scripts, since watchdog presence, register layout, and the daemon managing it are
   entirely target-specific.
 
+### Debugging interrupts, workqueues, and kthreads
+
+`taskset` only pins a *userspace process* — it works for anything your module does synchronously
+inside a syscall/VFS op triggered by a process you control (`insmod`, `rmmod`, a `cat`/`echo`
+against a sysfs file, an ioctl from your own test program, etc.), including a module that's already
+loaded and running (found via `/sys/module/<name>/sections/...` and loaded manually with
+`add-symbol-file`/`hbreak`, without using Debug on Init at all) — the core that ran the module's
+`init` doesn't matter once it's loaded; only the core that will run the code you're about to break
+on matters. But `taskset` has nothing to pin for interrupt handlers, workqueue callbacks, or a
+module's own kernel threads, since there's no userspace process to point it at. Same underlying
+idea (force the code onto core 0, the one the breakpoint is armed on), different mechanism per
+subsystem:
+
+* **Interrupt handlers.** Pin the IRQ itself, not a process, via `/proc/irq/<N>/smp_affinity`:
+  ```bash
+  cat /proc/interrupts                    # find <N> for your driver, by name
+  echo 1 > /proc/irq/<N>/smp_affinity     # bitmask 1 = CPU0 only
+  ```
+  Not all interrupts allow this — some are hardware-pinned per core (timers, IPIs) and reject a
+  changed affinity. Ordinary peripheral IRQs (GPIO, UART, network, etc.) normally accept it.
+
+* **Workqueues.** Depends on how the module queues work:
+  * `schedule_work()`/`queue_work()` on a normal (non-`WQ_UNBOUND`) workqueue: by default the work
+    item runs on the *same core that queued it*. If you control/pin whatever triggers the
+    `schedule_work()` call (a process via `taskset`, or an IRQ via `smp_affinity` above), the work
+    callback follows it onto the same core — no extra step needed.
+  * A module-private workqueue created with `WQ_SYSFS`: it exposes
+    `/sys/devices/virtual/workqueue/<name>/cpumask` — write a mask to restrict which cores it's
+    allowed to use.
+  * `WQ_UNBOUND` with no `WQ_SYSFS` cpumask: not pinnable from userspace at all; see `target smp`
+    below.
+
+* **The module's own kthreads** (`kthread_run()`/`kthread_create()`). These have a normal PID, so
+  pin them exactly like any process, just with `-p` instead of a command to launch:
+  ```bash
+  ps | grep <thread name>
+  taskset -p 0x1 <pid>          # pin to CPU0
+  ```
+
+* **Nothing above applies** (an unpinnable `WQ_UNBOUND` workqueue, a hardware-pinned interrupt, or a
+  bug that only reproduces with genuine multi-core parallelism, where forcing everything onto one
+  core would hide it). This is the case `target smp` exists for — see "Multi-core (SMP) targets"
+  above, including the hardware-watchdog trade-off. There is no way to get breakpoint coverage on
+  every core without also getting the whole-group cross-halt that comes with it; picking per-context
+  pinning above versus `target smp` here is a real trade-off, not a Seer limitation.
+
 ### References
 
 * [OpenOCD User's Guide](https://openocd.org/doc/html/index.html)

--- a/src/resources/mi-python/MIDebugOnInit.py
+++ b/src/resources/mi-python/MIDebugOnInit.py
@@ -1,0 +1,515 @@
+# SPDX-License-Identifier: MIT
+#
+# Python MI command that drives gdb through "debug a kernel module from insmod".
+#
+#   -debug-on-init MODULE SERIAL SYMFILE SRCDIR CMD
+#
+#       MODULE   kernel module name, as shown by lsmod
+#       SERIAL   target serial device to write CMD to (e.g. /dev/ttyUSB0)
+#       SYMFILE  the module's .ko, built with debug info
+#       SRCDIR   directory to add to gdb's source search path
+#       CMD      shell command that loads the module on the target (insmod ...)
+#
+# The whole sequence runs inside gdb from one command: gdb.execute("continue")
+# from a Python command blocks until the inferior stops, so the steps run in
+# order with no worker thread and no MI-async races to orchestrate around - that
+# is the entire point of doing this in Python instead of from Seer's C++ side.
+# (We can't 'set mi-async off' - it's rejected whenever a live inferior exists,
+# which for a remote/OpenOCD target is the whole session.)
+#
+# On success gdb is left stopped at the module's init function with the
+# module's symbols loaded at their real addresses.
+
+import gdb
+import os
+import re
+import signal
+import threading
+import time
+
+TIMEOUT_S      = 30.0    # how long to wait for a breakpoint to be hit
+SERIAL_DELAY_S = 0.7     # wait after 'continue' before writing CMD, so the target is running
+SKIP_SECTIONS  = {".symtab", ".strtab", ".shstrtab"}   # not placeable by add-symbol-file
+LOGFILE        = os.environ.get("SEER_DEBUG_ON_INIT_LOG", "/tmp/seer-debug-on-init.log")
+
+
+def _log(msg):
+    # Persist progress to a file so it can be inspected even while gdb is blocked in 'continue'
+    # (the MI channel is silent then). Thread-safe: one open()/write()/close() per line.
+    line = "%s  %s\n" % (time.strftime("%H:%M:%S"), msg)
+    try:
+        with open(LOGFILE, "a") as f:
+            f.write(line)
+    except Exception:
+        pass
+
+
+class _Timeout:
+    """
+    Fires SIGINT into gdb after 'seconds' unless cancelled first. A blocking
+    'continue' cannot be interrupted by anything else, so this simulates the
+    user pressing Ctrl-C: gdb stops the target, 'continue' returns, and the
+    caller notices it did not land on the expected breakpoint.
+    """
+
+    def __init__(self, seconds):
+        self._lock  = threading.Lock()
+        self._done  = False
+        self._fired = False
+        self._timer = threading.Timer(seconds, self._fire)
+        self._timer.daemon = True
+
+    def start(self):
+        self._timer.start()
+
+    def _fire(self):
+        with self._lock:
+            if self._done:
+                return
+            self._fired = True
+        _log("timeout: sending SIGINT to gdb to break the blocking 'continue'")
+        # Retry a few times: one SIGINT may be swallowed while gdb/OpenOCD is mid-transaction.
+        for _ in range(5):
+            try:
+                os.kill(os.getpid(), signal.SIGINT)
+            except Exception:
+                pass
+            time.sleep(0.5)
+            with self._lock:
+                if self._done:
+                    return
+
+    def cancel(self):
+        with self._lock:
+            self._done = True
+        self._timer.cancel()
+
+    @property
+    def fired(self):
+        return self._fired
+
+
+def _diag(msg):
+    # Progress marker: gdb console log (main thread only) + the persistent file.
+    _log(msg)
+    try:
+        gdb.write("@debug-on-init: %s\n" % msg)
+        gdb.flush()
+    except Exception:
+        pass
+
+
+def _autobool_str(v):
+    # gdb.parameter() gives an auto-boolean back as True / False / None.
+    if v is None:
+        return "auto"
+    return "on" if v else "off"
+
+
+def _target_running():
+    inf = gdb.selected_inferior()
+    if not inf or not inf.threads():
+        return False
+    return any(t.is_running() for t in inf.threads())
+
+
+def _really_stopped():
+    if _target_running():
+        return False
+    try:
+        gdb.selected_frame()
+        return True
+    except gdb.error:
+        return False
+
+
+
+
+def _module_is_loaded(name):
+    try:
+        modules = gdb.lookup_global_symbol("modules").value()
+        mtype   = gdb.lookup_type("struct module")
+        offset  = mtype['list'].bitpos // 8
+        voidp   = gdb.lookup_type("void").pointer()
+    except Exception:
+        return False
+
+    cur  = modules['next']
+    head = modules.address
+    guard = 0
+    while cur != head and guard < 4096:
+        guard += 1
+        try:
+            mod = (cur.cast(voidp) - offset).cast(mtype.pointer()).dereference()
+            if mod['name'].string() == name:
+                return True
+            cur = cur['next']
+        except gdb.error:
+            break
+    return False
+
+
+def _section_name(attr):
+    for path in (('battr', 'attr', 'name'), ('attr', 'name'), ('name',)):
+        try:
+            v = attr
+            for f in path:
+                v = v[f]
+            return v.string()
+        except (gdb.error, KeyError):
+            continue
+    return None
+
+
+def _read_sections():
+    mod  = gdb.parse_and_eval("mod")
+    sect = mod['sect_attrs']
+    n    = int(sect['nsections'])
+    arr  = sect['attrs']
+
+    out = {}
+    for i in range(n):
+        a    = arr[i]
+        name = _section_name(a)
+        if not name:
+            continue
+        try:
+            out[name] = int(a['address'])
+        except (gdb.error, KeyError):
+            continue
+    return out
+
+
+def _find_return_line(path):
+    call = re.compile(r'do_init_module\s*\(\s*mod\s*\)')
+    ret  = re.compile(r'^\s*return\s+do_init_module\s*\(\s*mod\s*\)')
+    fallback = None
+    with open(path, 'r', errors='replace') as f:
+        for i, line in enumerate(f, 1):
+            if not call.search(line):
+                continue
+            if ret.search(line):
+                return i
+            if fallback is None:
+                fallback = i
+    return fallback
+
+
+def _continue_blocking(timeout_s):
+    """Run 'continue' and wait for the stop. Returns True if it timed out."""
+    t = _Timeout(timeout_s)
+    t.start()
+    try:
+        gdb.execute("continue")
+    except KeyboardInterrupt:
+        pass
+    except gdb.error:
+        pass
+    finally:
+        # gdb.execute("continue") from a command blocks until the stop; if this build somehow
+        # returns early, wait the target out here rather than reading it while it runs. The
+        # _Timeout still fires SIGINT to break a genuine hang.
+        end = time.time() + timeout_s
+        while _target_running() and time.time() < end:
+            time.sleep(0.05)
+        t.cancel()
+    return t.fired
+
+
+class MIDebugOnInit(gdb.MICommand):
+    """
+    -debug-on-init MODULE SERIAL SYMFILE SRCDIR CMD
+
+    Drive gdb through debugging a kernel module from its insmod:
+      - break where load_module() is about to call do_init_module(),
+      - load CMD onto the target over SERIAL,
+      - read the module's section load addresses from mod->sect_attrs,
+      - add-symbol-file SYMFILE at those addresses and 'directory SRCDIR',
+      - set a breakpoint at the module's init function and run to it.
+
+    The target must already be stopped (Seer sends a SIGINT first).
+    """
+
+    def __init__(self):
+        super(MIDebugOnInit, self).__init__("-debug-on-init")
+
+    def invoke(self, argv):
+        # Always emit one '@debug-on-init-complete <ok|error> <detail>' console line so Seer can
+        # clear its "in progress" state and tell the user what happened, whether we return a
+        # result or raise.
+        try:
+            result = self._run(argv)
+            gdb.write("@debug-on-init-complete ok %s\n" % result.get("warnings", ""))
+            gdb.flush()
+            return result
+        except gdb.GdbError as e:
+            gdb.write("@debug-on-init-complete error %s\n" % str(e))
+            gdb.flush()
+            raise
+        except Exception as e:
+            gdb.write("@debug-on-init-complete error %s\n" % str(e))
+            gdb.flush()
+            raise gdb.GdbError("-debug-on-init: %s" % e)
+
+    def _run(self, argv):
+        if len(argv) < 5:
+            raise gdb.GdbError("-debug-on-init: expects MODULE SERIAL SYMFILE SRCDIR CMD")
+
+        module  = argv[0]
+        serial  = argv[1]
+        symfile = argv[2]
+        srcdir  = argv[3]
+        command = " ".join(argv[4:])
+
+        try:
+            open(LOGFILE, "w").close()   # fresh log per run
+        except Exception:
+            pass
+        _log("start: module=%s serial=%s cmd=%r" % (module, serial, command))
+
+        inf = gdb.selected_inferior()
+        if not inf or not inf.threads():
+            raise gdb.GdbError("-debug-on-init: no running inferior")
+
+        # The target must be stopped. Seer SIGINTs it before sending this command, so normally we're
+        # already stopped here; interrupt as a fallback. A Python MI command can't wait for a stop
+        # itself (gdb's event loop doesn't run inside invoke()), so if it's still running after
+        # this, bail and let the user retry.
+        if not _really_stopped():
+            try:
+                gdb.execute("interrupt")
+            except gdb.error:
+                pass
+            for _ in range(50):
+                if _really_stopped():
+                    break
+                time.sleep(0.1)
+        if not _really_stopped():
+            raise gdb.GdbError("-debug-on-init: target is still running - stop it first, then retry")
+
+        # NOTE: do NOT 'set breakpoint always-inserted on' here. On this OpenOCD SMP target it makes
+        # gdb insert the breakpoint once and never refresh it, and OpenOCD then loses it - the
+        # breakpoint is silently never hit even though the code runs through it. The default
+        # ('auto': remove on stop, freshly re-insert on each resume) is what actually works.
+
+        saved_bps   = [(bp, bp.enabled) for bp in (gdb.breakpoints() or [])]
+        created_bps = []
+        warnings    = []
+
+        def restore_settings():
+            pass
+
+        def restore_user_bps():
+            for bp, enabled in saved_bps:
+                try:
+                    bp.enabled = enabled
+                except Exception:
+                    pass
+
+        def delete_created_bps():
+            for bp in created_bps:
+                try:
+                    bp.delete()
+                except Exception:
+                    pass
+            created_bps.clear()
+
+        def bail(msg):
+            # Leave the target stopped where it is - the user can see the failure point and
+            # continue manually.
+            delete_created_bps()
+            restore_user_bps()
+            restore_settings()
+            raise gdb.GdbError(msg)
+
+        try:
+            if _module_is_loaded(module):
+                bail("module '%s' is already loaded - unload it first before debug on init" % module)
+
+            for bp, _ in saved_bps:
+                try:
+                    bp.enabled = False
+                except Exception:
+                    pass
+
+            # --- Resolve load_module()'s source file -------------------------------
+            lm_file = None
+            try:
+                sals = gdb.decode_line("load_module")[1]
+                if sals and sals[0].symtab is not None:
+                    lm_file = sals[0].symtab.fullname()
+            except gdb.error:
+                pass
+            if lm_file is None:
+                sym = (gdb.lookup_global_symbol("load_module")
+                       or gdb.lookup_static_symbol("load_module"))
+                if sym is not None and sym.symtab is not None:
+                    lm_file = sym.symtab.fullname()
+            if lm_file is None:
+                bail("could not resolve load_module() - are the kernel's debug symbols loaded?")
+
+            line = _find_return_line(lm_file)
+            if not line:
+                bail("could not find 'return do_init_module(mod)' in %s" % lm_file)
+
+            # --- Break at that line, then load the module over serial --------------
+            # Permanent hardware breakpoint ('hbreak', not 'thbreak') - that is what hits reliably
+            # when done by hand on this target; a temporary HW breakpoint gets missed. We delete it
+            # ourselves once it's hit. (Project rule: hardware breakpoints only.)
+            spec = "%s:%d" % (lm_file, line)
+            gdb.execute("hbreak " + spec)
+            created_bps.append(gdb.breakpoints()[-1])
+            _diag("armed hw breakpoint at %s" % spec)
+
+            data = (command + "\n").encode()
+
+            def _send():
+                time.sleep(SERIAL_DELAY_S)
+                try:
+                    fd = os.open(serial, os.O_WRONLY | os.O_NONBLOCK | os.O_NOCTTY)
+                except OSError as e:
+                    _log("serial: cannot open %s: %s" % (serial, e))
+                    return
+                try:
+                    buf = data
+                    deadline = time.time() + 5.0
+                    while buf and time.time() < deadline:
+                        try:
+                            buf = buf[os.write(fd, buf):]
+                        except BlockingIOError:
+                            time.sleep(0.05)
+                    _log("serial: wrote %r to %s (%d bytes unsent)" % (data, serial, len(buf)))
+                finally:
+                    os.close(fd)
+
+            threading.Thread(target=_send, daemon=True).start()
+
+            try:
+                _log("breakpoints before continue:\n" + gdb.execute("info breakpoints", to_string=True))
+            except Exception:
+                pass
+
+            _diag("continuing, waiting for %s" % spec)
+            timed_out = _continue_blocking(TIMEOUT_S)
+
+            where = "?"
+            try:
+                where = gdb.selected_frame().name() or "?"
+            except Exception:
+                pass
+            _diag("stopped in %s (timed_out=%s)" % (where, timed_out))
+
+            # Forensics: did the breakpoints ever get inserted / hit?
+            for cmd in ("info breakpoints", "p/x $pc", "bt 3"):
+                try:
+                    _log("%s ->\n%s" % (cmd, gdb.execute(cmd, to_string=True)))
+                except Exception as e:
+                    _log("%s -> <%s>" % (cmd, e))
+
+            if where != "load_module":
+                if timed_out:
+                    bail("timed out after %ds - the breakpoint at %s was never hit even though the "
+                         "module loaded (stopped in %s). The target is dropping this breakpoint. Try "
+                         "pinning the loader to the debugged core: 'taskset -c 0 %s'."
+                         % (int(TIMEOUT_S), spec, where, command))
+                bail("stopped in %s, not load_module(), while waiting for the module load" % where)
+
+            # temporary breakpoints delete themselves on the hit; delete whatever's left.
+            for b in list(created_bps):
+                try:
+                    if b.is_valid():
+                        b.delete()
+                except Exception:
+                    pass
+            created_bps.clear()
+
+            # --- Read the module's section load addresses -------------------------
+            try:
+                sections = _read_sections()
+            except gdb.error as e:
+                sections = {}
+                warnings.append("sect_attrs: %s" % e)
+
+            if ".text" not in sections:
+                bail("could not read mod->sect_attrs section addresses")
+            _diag("read %d sections (.text = 0x%x)" % (len(sections), sections[".text"]))
+
+            # --- Load the module's symbols at those addresses --------------------
+            parts = ["add-symbol-file", symfile, "0x%x" % sections[".text"]]
+            for name, addr in sorted(sections.items()):
+                if name == ".text" or name in SKIP_SECTIONS:
+                    continue
+                parts += ["-s", name, "0x%x" % addr]
+            try:
+                gdb.execute(" ".join(parts), to_string=True)
+            except gdb.error as e:
+                warnings.append("add-symbol-file: %s" % e)
+
+            try:
+                gdb.execute("directory " + srcdir, to_string=True)
+            except gdb.error as e:
+                warnings.append("directory: %s" % e)
+
+            # --- Breakpoint at the module's init function -----------------------
+            init_specs = ["init_module"]
+            if ".init.text" in sections:
+                init_specs.append("*0x%x" % sections[".init.text"])
+
+            init_bp = None
+            for spec in init_specs:
+                try:
+                    gdb.execute("hbreak " + spec)      # permanent hardware breakpoint
+                    init_bp = gdb.breakpoints()[-1]
+                    break
+                except gdb.error:
+                    continue
+            if init_bp is None:
+                warnings.append("could not set a breakpoint at the module's init function")
+            else:
+                _diag("init breakpoint set (%s)" % init_bp.location)
+
+            # --- Restore the user's breakpoints and run to the init breakpoint --
+            restore_user_bps()
+
+            init_timed_out = False
+            if init_bp is not None:
+                _diag("continuing to module init")
+                init_timed_out = _continue_blocking(TIMEOUT_S)
+                try:
+                    _log("after init continue:\n" + gdb.execute("info breakpoints", to_string=True))
+                except Exception:
+                    pass
+                # Delete our init breakpoint - the user takes over from here.
+                try:
+                    if init_bp.is_valid():
+                        init_bp.delete()
+                except Exception:
+                    pass
+
+            if init_timed_out:
+                warnings.append("module init breakpoint was not hit within %ds" % int(TIMEOUT_S))
+
+            result = {
+                "result":     "done",
+                "module":     module,
+                "sourcefile": lm_file,
+                "line":       str(line),
+                "sections":   str(len(sections)),
+            }
+            if warnings:
+                result["warnings"] = "; ".join(warnings)
+            return result
+
+        except gdb.GdbError:
+            raise
+        except Exception as e:
+            try:
+                delete_created_bps()
+                restore_user_bps()
+                restore_settings()
+            except Exception:
+                pass
+            raise gdb.GdbError("-debug-on-init: %s" % e)
+
+
+MIDebugOnInit()

--- a/src/resources/mi-python/MIDebugOnInit.py
+++ b/src/resources/mi-python/MIDebugOnInit.py
@@ -99,6 +99,18 @@ def _diag(msg):
         pass
 
 
+def _diag_warn(msg):
+    # Non-fatal notice for Seer: shown as a popup but does NOT end the sequence (unlike
+    # '@debug-on-init-complete') - used e.g. when we can't write CMD to SERIAL ourselves, so the
+    # user can type it manually while we keep waiting on the breakpoint. Main thread only.
+    _log("WARNING: " + msg)
+    try:
+        gdb.write("@debug-on-init-warning %s\n" % msg)
+        gdb.flush()
+    except Exception:
+        pass
+
+
 def _autobool_str(v):
     # gdb.parameter() gives an auto-boolean back as True / False / None.
     if v is None:
@@ -368,13 +380,20 @@ class MIDebugOnInit(gdb.MICommand):
 
             data = (command + "\n").encode()
 
-            def _send():
+            # Open the serial port now, in the main thread, so a permission error (e.g. /dev/ttyUSB0
+            # owned by root) is caught and reported immediately instead of only surfacing as an
+            # opaque 30s "breakpoint never hit" timeout. This does NOT abort the sequence: we still
+            # arm the breakpoint and wait for it below - the user can type CMD manually on the
+            # target's console in the meantime.
+            try:
+                serial_fd = os.open(serial, os.O_WRONLY | os.O_NONBLOCK | os.O_NOCTTY)
+            except OSError as e:
+                serial_fd = None
+                _diag_warn("Cannot open %s (%s) - enter this command manually on the target now: \n%s"
+                           % (serial, e, command))
+
+            def _send(fd):
                 time.sleep(SERIAL_DELAY_S)
-                try:
-                    fd = os.open(serial, os.O_WRONLY | os.O_NONBLOCK | os.O_NOCTTY)
-                except OSError as e:
-                    _log("serial: cannot open %s: %s" % (serial, e))
-                    return
                 try:
                     buf = data
                     deadline = time.time() + 5.0
@@ -387,7 +406,8 @@ class MIDebugOnInit(gdb.MICommand):
                 finally:
                     os.close(fd)
 
-            threading.Thread(target=_send, daemon=True).start()
+            if serial_fd is not None:
+                threading.Thread(target=_send, args=(serial_fd,), daemon=True).start()
 
             try:
                 _log("breakpoints before continue:\n" + gdb.execute("info breakpoints", to_string=True))

--- a/src/resources/mi-python/MIDebugOnInit.py
+++ b/src/resources/mi-python/MIDebugOnInit.py
@@ -127,7 +127,12 @@ def _really_stopped():
 
 def _module_is_loaded(name):
     try:
-        modules = gdb.lookup_global_symbol("modules").value()
+        # The kernel's "modules" list head is `static` (kernel/module/main.c), so
+        # lookup_global_symbol() alone returns None here - same fallback used for
+        # load_module() below.
+        sym = (gdb.lookup_global_symbol("modules")
+               or gdb.lookup_static_symbol("modules"))
+        modules = sym.value()
         mtype   = gdb.lookup_type("struct module")
         offset  = mtype['list'].bitpos // 8
         voidp   = gdb.lookup_type("void").pointer()

--- a/src/resources/mi-python/MIlsmod.py
+++ b/src/resources/mi-python/MIlsmod.py
@@ -1,0 +1,93 @@
+# File: lsmod.py
+
+import gdb
+
+class MIlsmod(gdb.MICommand):
+    def __init__(self):
+        self._mode = "default"  # Placeholder mode
+        super(MIlsmod, self).__init__("-lsmod")  # MI command name
+
+    def invoke(self, argv):
+        try:
+            # Get filter string from argv (if provided)
+            filter_str = argv[0] if argv else None
+
+            # Try to access 'modules' symbol
+            modules_symbol = gdb.lookup_global_symbol("modules")
+            if not modules_symbol:
+                try:
+                    modules = gdb.parse_and_eval("modules")
+                    if not modules:
+                        return {
+                            "result": "error",
+                            "message": "Symbol 'modules' not found via parse_and_eval. Ensure kernel debugging symbols are loaded."
+                        }
+                except gdb.error:
+                    return {
+                        "result": "error",
+                        "message": "Symbol 'modules' not found. Run 'symbol-file vmlinux' and ensure CONFIG_DEBUG_INFO=y, CONFIG_MODULES=y."
+                    }
+            else:
+                modules = modules_symbol.value()
+
+            # Diagnostic: Print address of modules
+            gdb.write(f"Debug: Address of 'modules' = {modules.address}\n")
+
+            # Get the type of 'struct module'
+            try:
+                module_type = gdb.lookup_type("struct module")
+            except gdb.error:
+                return {
+                    "result": "error",
+                    "message": "Type 'struct module' not found. Ensure kernel debugging symbols are available."
+                }
+
+            # Calculate offset of 'list' field
+            try:
+                offset = module_type['list'].bitpos // 8
+            except gdb.error:
+                return {
+                    "result": "error",
+                    "message": "Field 'list' not found in 'struct module'. Check kernel version."
+                }
+
+            # Start at modules.next
+            current = modules['next']
+            modules_list = []
+
+            # Loop until we reach the head of the list
+            while current != modules.address:
+                # Compute the module pointer
+                mod_ptr = current.cast(gdb.lookup_type("void").pointer()) - offset
+                mod = mod_ptr.cast(module_type.pointer()).dereference()
+
+                # Get the module name
+                try:
+                    mod_name = mod['name'].string()
+                except gdb.error:
+                    return {
+                        "result": "error",
+                        "message": "Failed to read module name. Possible corrupted module data."
+                    }
+
+                # Break if name is empty
+                if mod_name == "":
+                    break
+
+                # Add module to list if it matches filter exactly (case-sensitive) or no filter
+                if filter_str is None or filter_str == mod_name:
+                    modules_list.append(f'{{name="{mod_name}"}}')
+
+                # Move to next entry
+                current = current['next']
+
+            # Format MI output
+            modules_str = f"[{', '.join(modules_list)}]" if modules_list else "[]"
+            return {"result": "done", "modules": modules_str}
+
+        except gdb.error as e:
+            return {"result": "error", "message": f"GDB error: {str(e)}"}
+        except Exception as e:
+            return {"result": "error", "message": f"Unexpected error: {str(e)}"}
+
+MIlsmod()


### PR DESCRIPTION
A kernel module is a piece of code that extends system capabilities — such as adding device drivers or file system support.
It can do many things: toggle an LED, drive a motor, or handle a monitor, a camera, and so on.
Kernel modules account for up to 70% of the source code in the upstream Linux kernel.

There are two types of kernel module: loadable and built-in.
Built-in kernel modules are "baked into" or "embedded in" the kernel at build time. They are essentially part of the kernel itself, so their load addresses are predetermined.

Loadable kernel modules are built into .ko files. A .ko file is essentially an ELF file in position-independent executable (PIE) format, which means it can be loaded and run at any arbitrary address.

As mentioned above, the load addresses of built-in kernel modules and of the Linux kernel itself are predetermined, which makes debugging them easy with JTAG.

The load address of a loadable kernel module, however, is unknown and only determined at runtime, which makes debugging more challenging.

Solution:
There is a Linux kernel function that can help us: `load_module()`.
It is responsible for parsing a kernel module, checking its compatibility, and loading it into the kernel's memory layout. It decides where each segment of the module — .text, .data, .rodata, and so on — will be placed.
By reading the relevant kernel variables, we can tell GDB which part of the module's memory is mapped to which part of the kernel's memory layout, and thus debug kernel modules through a GUI.