### PR TITLE
Fix: Array Visualizer handleText stack usage

### DIFF
--- a/src/SeerArrayVisualizerWidget.cpp
+++ b/src/SeerArrayVisualizerWidget.cpp
@@ -398,7 +398,10 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
 
     //qDebug() << text;
 
-    if (text.contains(QRegularExpression("^([0-9]+)\\^done,value="))) {
+    static const QRegularExpression valueResponse = QRegularExpression("^([0-9]+)\\^done,value=");
+    static const QRegularExpression memoryResponse = QRegularExpression("^([0-9]+)\\^done,memory=");
+	static const QRegularExpression errorResponse = QRegularExpression("^([0-9]+)\\^error,msg=");
+    if (text.contains(valueResponse)) {
 
         // 11^done,value="1"
         // 11^done,value="0x7fffffffd538"
@@ -527,7 +530,7 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
             handlebRefreshButton();
         }
 
-    }else if (text.contains(QRegularExpression("^([0-9]+)\\^done,memory="))) {
+    }else if (text.contains(memoryResponse)) {
 
         // 3^done,memory=[{begin="0x0000000000613e70",offset="0x0000000000000000",end="0x0000000000613e71",contents="00"}]
         // 4^done,memory=[{begin="0x0000000000613e70",offset="0x0000000000000000",end="0x0000000000613ed4",contents="000000000000000000000000"}]
@@ -632,7 +635,7 @@ void SeerArrayVisualizerWidget::handleText (const QString& text) {
             }
         }
 
-    }else if (text.contains(QRegularExpression("^([0-9]+)\\^error,msg="))) {
+    }else if (text.contains(errorResponse)) {
 
         // 12^error,msg="No symbol \"return\" in current context."
         // 13^error,msg="No symbol \"cout\" in current context."


### PR DESCRIPTION
## Problem
In the current implementation `handleText` method creates `QRegularExpression` object each time on stack every time this method is called then removes it from stack. 

Here is the symbols before fix:
```sh
~/Dev/forks/seer/src/build main !1 ❯ cat repro_1.txt                             21:38:14
00000000000031c0 T SeerArrayVisualizerWidget::handleText(QString const&)
```
all global on text segment and creates the object each time it's called.

## Fix

The fix is store these objects in .bss since they are not changeable objects and can be compiled and stored before program started/handleText called.

Here is the symbols after the fix:
```sh
~/Dev/fo/seer/s/build fix-arrayviz-stack ❯ cat repro_static_const_full.txt       21:46:12
0000000000000028 b guard variable for SeerArrayVisualizerWidget::handleText(QString const&)::errorResponse
0000000000000008 b guard variable for SeerArrayVisualizerWidget::handleText(QString const&)::valueResponse
0000000000000018 b guard variable for SeerArrayVisualizerWidget::handleText(QString const&)::memoryResponse
00000000000031c0 T SeerArrayVisualizerWidget::handleText(QString const&)
0000000000000020 b SeerArrayVisualizerWidget::handleText(QString const&)::errorResponse
0000000000000000 b SeerArrayVisualizerWidget::handleText(QString const&)::valueResponse
0000000000000010 b SeerArrayVisualizerWidget::handleText(QString const&)::memoryResponse
```
Which means now every `QRegulerExpression` object in `handleText` method lives under local .bss and they have zero-initialization cost.

```sh
0x00   valueResponse            8 byte
0x08   guard valueResponse      8 byte
0x10   memoryResponse           8 byte
0x18   guard memoryResponse     8 byte
0x20   errorResponse            8 byte
0x28   guard errorResponse      8 byte
``` 
The memory cost is not 48 bytes once in the programs lifetime. 

## Benchmark

I ran couple of benchmarks with microbench. 

```sh
# run no. 1
construction only             94.5 ns
construction + compile     26772.5 ns

lines processed             270000
per-call construction      49503.4 ns/line
static const                 472.7 ns/line
saved                      49030.7 ns/line   (104.7x)

# run no. 2
construction only             91.6 ns
construction + compile     27152.7 ns

lines processed             270000
per-call construction      47951.2 ns/line
static const                 465.7 ns/line
saved                      47485.5 ns/line   (103.0x) 
```

so the fix approx. saves up 100% performance gain. I also added the benchmark code to the attachments.
[regexbench.cpp](https://github.com/user-attachments/files/31387609/regexbench.cpp)
