### PR TITLE
Fix matrix visualizer slips

### DIFF
--- a/src/SeerEditorWidgetAssemblyAreas.cpp
+++ b/src/SeerEditorWidgetAssemblyAreas.cpp
@@ -1416,7 +1416,7 @@ void SeerEditorWidgetAssemblyArea::showContextMenu (const QPoint& pos, const QPo
 
     QMenu matrixVisualizerMenu("Add address to a Matrix Visualizer");
     matrixVisualizerMenu.addAction(addMatrixAddressVisualizerAction);
-    menu.addMenu(&arrayVisualizerMenu);
+    menu.addMenu(&matrixVisualizerMenu);
 
     QMenu structVisualizerMenu("Add address to a Struct Visualizer");
     structVisualizerMenu.addAction(addStructAddressVisualizerAction);

--- a/src/SeerMatrixVisualizerWidget.cpp
+++ b/src/SeerMatrixVisualizerWidget.cpp
@@ -550,7 +550,7 @@ void SeerMatrixVisualizerWidget::handleElementStrideLineEdit () {
 
     // A regular integer? Return.
     QRegularExpression re("[0-9]+");
-    QRegularExpressionMatch match = re.match(variableRows());
+    QRegularExpressionMatch match = re.match(variableStride());
 
     if (match.hasMatch()) {
         return;


### PR DESCRIPTION
Two small, unrelated-looking one-liners with the same root cause (a
copy-paste from a sibling block), both making a Matrix Visualizer entry
point silently inoperative:

- `SeerMatrixVisualizerWidget::handleElementStrideLineEdit()` matched the
  **rows** field instead of the stride field. With rows set to a literal
  integer (the common case), the early-return always triggered, so a
  stride given as a *variable* was never sent to gdb for evaluation —
  typing it just did nothing. The three sibling handlers
  (rows/columns/offset) each match their own field.

- In the assembly area's context menu, the "Add address to a Matrix
  Visualizer" submenu was created but `&arrayVisualizerMenu` was added a
  second time in its place. Since re-adding a menu just moves it, the net
  effect is that the Matrix submenu never appears in the context menu and
  `addMatrixAddressVisualizerAction` is unreachable.

### Testing

Qt 6.4.2, Linux. With `tests/helloscatter`: 

- entering a program variable in the stride field now evaluates it (the field resolves to its value and
the view refreshes; before, typing it did nothing). 

<img width="3828" height="2110" alt="Capture d’écran du 2026-08-29 14-44-55" src="https://github.com/user-attachments/assets/fc862ae3-d8f8-4738-933b-704ce9b1061f" />

<img width="3831" height="2114" alt="Capture d’écran du 2026-08-29 14-48-36" src="https://github.com/user-attachments/assets/ef028b5d-6b48-45ce-9f00-4da17c88a31e" />

- In the assembly view, right-clicking with an address selected now offers all four visualizer
submenus, Matrix included (before: only Memory/Array/Struct).

<img width="3829" height="2101" alt="Capture d’écran du 2026-08-29 14-46-16" src="https://github.com/user-attachments/assets/e9ad5d4a-9984-4dc3-ab04-da34ac515961" />

<img width="3835" height="2123" alt="Capture d’écran du 2026-08-29 14-49-26" src="https://github.com/user-attachments/assets/446697f5-8239-4b4d-8343-5a77ce6d3f4b" />
