### PR TITLE
Fix project loading slips, unread gdb stderr, and a missing parenthesis

### DIFF
--- a/src/GdbMonitor.cpp
+++ b/src/GdbMonitor.cpp
@@ -43,6 +43,11 @@ void GdbMonitor::handleReadyReadStandardError () {
 
     QProcess* p = (QProcess*)sender();
 
+    // canReadLine()/readLine() work on the current read channel, which
+    // defaults to stdout. Point them at stderr for this handler, then
+    // switch back for the stdout handler.
+    p->setReadChannel(QProcess::StandardError);
+
     // Read a line at a time.
     while (p->canReadLine()) {
 
@@ -61,6 +66,8 @@ void GdbMonitor::handleReadyReadStandardError () {
         // Start broadcasting it around.
         emit allTextOutput(text);
     }
+
+    p->setReadChannel(QProcess::StandardOutput);
 }
 
 void GdbMonitor::handleReadyReadStandardOutput () {

--- a/src/SeerDebugDialog.cpp
+++ b/src/SeerDebugDialog.cpp
@@ -754,7 +754,7 @@ bool SeerDebugDialog::loadJsonDoc (const QJsonDocument& jsonDoc, const QString& 
 
             runProgramArgumentsLineEdit->setText(runModeJson["arguments"].toString());
             loadBreakpointsFilenameLineEdit->setText(runModeJson["breakpointsfile"].toString());
-            rrLoadBreakpointsFilenameLineEdit->setText(startModeJson["breakpointsfile"].toString());
+            rrLoadBreakpointsFilenameLineEdit->setText(runModeJson["breakpointsfile"].toString());
 
             if (runModeJson["nobreak"].toBool()) {
                 noBreakpointRadioButton->setChecked(true);
@@ -797,7 +797,7 @@ bool SeerDebugDialog::loadJsonDoc (const QJsonDocument& jsonDoc, const QString& 
                 breakpointInFunctionRadioButton->setChecked(true);
             }
 
-            if (runModeJson["breakatfirstinstruction"].toBool()) {
+            if (startModeJson["breakatfirstinstruction"].toBool()) {
                 breakpointAtFirstInstructionRadioButton->setChecked(true);
             }
 

--- a/src/SeerGdbConfigPage.cpp
+++ b/src/SeerGdbConfigPage.cpp
@@ -132,7 +132,7 @@ void SeerGdbConfigPage::reset () {
 #ifdef SEER_GDB_NAME
     setGdbProgram(STRINGIFY(SEER_GDB_NAME));
 #else
-    setGdbProgram("/usr/bin/gdb";
+    setGdbProgram("/usr/bin/gdb");
 #endif
 
 #ifdef SEER_GDB_LAUNCHER


### PR DESCRIPTION
Three small independent fixes, one commit each.

**1. Project loading read the other mode's JSON object twice.** In
`SeerDebugDialog::loadProject()`, the run branch read
`startModeJson["breakpointsfile"]` for the RR field, and the start
branch read `runModeJson["breakatfirstinstruction"]`. A project file
only contains one mode section, so the other object is always empty
there. In practice this is harmless today: the start section is only
written when "break in main" is selected (so the flag it tests is
always false), and the run branch merely leaves the RR breakpoints
file field blank. Just two slips made to read their own object.

**2. The stderr handler read the stdout channel.**
`GdbMonitor::handleReadyReadStandardError()` used
`canReadLine()`/`readLine()`, which operate on the process's current
read channel — and that defaults to stdout. Anything gdb wrote to
stderr was never read (silent failures instead of a diagnostic), and if
a complete stdout line happened to be pending, the stderr handler could
consume an MI response meant for the normal routing. The handler now
switches the read channel to stderr and back. Verified with a small
harness driving `GdbMonitor` with a process writing to both channels:
before, the stderr lines are never delivered; after, they are, and MI
lines still route normally.

**3. A missing parenthesis in the non-`SEER_GDB_NAME` fallback** in
`SeerGdbConfigPage::reset()`. The branch is currently dead (CMake
always defines `SEER_GDB_NAME`) so this is a latent build break, not a
user-visible bug: compiling that file without the define fails at
exactly that line, and compiles clean with the fix.

### Testing

Qt 6.4.2, Linux. Project round-trip: a run-mode project with a
breakpoints file, saved and reloaded, now also fills the RR tab's
breakpoints file field like the other branches do; a "break in main"
project round-trips unchanged. GdbMonitor: harness described above, plus a normal debug
session to check MI routing is unchanged. The parenthesis branch:
compiled with `-fsyntax-only` and the define removed.
